### PR TITLE
Update prefix passing, get-config return

### DIFF
--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -3,8 +3,10 @@ const help = require('./help');
 const Discord = require('discord.js');
 /**
  * Bootstraps all commands to the client.
+ * @param {Object.client} client the discord client
+ * @param {Object.config} config the application config
  */
-module.exports = function bootstrap(client) {
+module.exports = function bootstrap({ client, config }) {
   const commands = [eightball, help];
 
   client.on('guildMemberAdd', (member) => {
@@ -26,7 +28,6 @@ module.exports = function bootstrap(client) {
       .find((ch) => ch.name === 'introduction')
       .send('**' + member.user.username + '** has left the server! :(');
   });
-
   client.on('message', (message) => {
     for (let command of commands) {
       if (message.content.startsWith(command.prefix)) {

--- a/src/config/get-config.js
+++ b/src/config/get-config.js
@@ -8,7 +8,17 @@
 require('dotenv').config();
 
 module.exports = function getConfig() {
-  return Promise.resolve({
-    TOKEN: process.env.TOKEN
-  });
+  return {
+    /**
+     * The discord token
+     */
+    TOKEN: process.env.TOKEN,
+    /**
+     * The bots prefix which should be placed in-front of
+     * every command. Defaults to '!FCC' if nothing was given
+     *  **note** this is not used yet, all command still follow the :
+     * `!myCommand` format.
+     */
+    PREFIX: process.env.PREFIX
+  };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,12 @@ const client = new Client();
   try {
     // this iife is so we can get "top level await"
     console.log('Initalizing...');
-    const config = await getConfig();
+    const config = getConfig();
     validateConfig(config);
     // rig up client callbacks
     client.on('error', console.error);
 
-    bootstrap(client);
+    bootstrap({ client, config });
 
     client.on('message', (message) => {
       console.log('>> ', message.content);


### PR DESCRIPTION
- get-config no longer returns a promise
- get-config takes in PREFIX, is un-used for now
- bootstrap now takes in client, for future PREFIX support

Closes #20

Related to #11