### PR TITLE
Make help command auto-updating

### DIFF
--- a/src/commands/eightball.js
+++ b/src/commands/eightball.js
@@ -1,6 +1,7 @@
 module.exports = {
   prefix: '!eightball',
-  description: 'Think of your question and get an answer from a magic pool ball!',
+  description:
+  'Think of your question and get an answer from a magic pool ball!',
   /**
    * @name eightBall
    * Randomly selects an option, and returns it to chat.

--- a/src/commands/eightball.js
+++ b/src/commands/eightball.js
@@ -1,7 +1,7 @@
 module.exports = {
   prefix: '!eightball',
   description:
-  'Think of your question and get an answer from a magic pool ball!',
+    'Think of your question and get an answer from a magic pool ball!',
   /**
    * @name eightBall
    * Randomly selects an option, and returns it to chat.

--- a/src/commands/eightball.js
+++ b/src/commands/eightball.js
@@ -1,5 +1,6 @@
 module.exports = {
   prefix: '!eightball',
+  description: "Think of your question and get an answer from a magic pool ball!",
   /**
    * @name eightBall
    * Randomly selects an option, and returns it to chat.

--- a/src/commands/eightball.js
+++ b/src/commands/eightball.js
@@ -1,5 +1,5 @@
 module.exports = {
-  prefix: '!eightball',
+  prefix: 'eightball',
   description:
     'Think of your question and get an answer from a magic pool ball!',
   /**

--- a/src/commands/eightball.js
+++ b/src/commands/eightball.js
@@ -1,6 +1,6 @@
 module.exports = {
   prefix: '!eightball',
-  description: "Think of your question and get an answer from a magic pool ball!",
+  description: 'Think of your question and get an answer from a magic pool ball!',
   /**
    * @name eightBall
    * Randomly selects an option, and returns it to chat.

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,5 +1,6 @@
 const Discord = require('discord.js');
 const fs = require('fs');
+const fsPromises = fs.promises;
 module.exports = {
   prefix: '!help',
   description: 'Get the commands currently available with this bot',
@@ -23,24 +24,24 @@ module.exports = {
         footer: { text: 'I am not affiliated with FreeCodeCamp in any way.' }
       };
 
-      fs.readdir(__dirname, (error, files) => {
-        if (error) {
-          console.error(error);
-        }
-        for (let i = 0; i < files.length; i++) {
-          let filename = files[i];
-          let lookup = require(`./${filename}`);
-          if (lookup.prefix == undefined || lookup.description == undefined) {
-            continue;
-          } else {
-            let fieldObj = {
-              name: lookup.prefix.substring(0, 255),
-              value: lookup.description.substring(0, 1023)
-            };
-            helpEmbed.fields.push(fieldObj);
+      fsPromises
+        .readdir(__dirname)
+        .then((result) => {
+          for (let i = 0; i < result.length; i++) {
+            const filename = result[i];
+            const lookup = require(`./${filename}`);
+            if (!lookup.prefix || !lookup.description) {
+              continue;
+            } else {
+              const fieldObj = {
+                name: lookup.prefix.substring(0, 255),
+                value: lookup.description.substring(0, 1023)
+              };
+              helpEmbed.fields.push(fieldObj);
+            }
           }
-        }
-      });
+        })
+        .catch((error) => console.log(error));
 
       message.author.send({ embed: helpEmbed });
     } catch (error) {

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,46 +1,49 @@
-const Discord = require('discord.js');
+const Discord = require("discord.js");
+const fs = require("fs");
 module.exports = {
-  prefix: '!help',
+  prefix: "!help",
+  description: "Get the commands currently available with this bot",
   /**
    * @name help
    * Displays currently available commands.
    *
    * @param {Discord.Message} message the message provided
-   *Use this format to add new commands:
-   *{name: "Command Name", value: "Command Description"},
+   * Now automatically adds new commands - make sure the .js file has a prefix and description,
    */
 
   command: async function help(message) {
     //console.log("help", message);
     try {
-      const helpEmbed = new Discord.MessageEmbed()
-        .setColor('#0099ff')
-        .setTitle('Bot Information')
-        .setDescription(
-          'Hello! I am a test bot created by bradtaniguchi and members of FreeCodeCamp.org ' +
-            'to experiment with the process of building a Discord Bot. You can view my source ' +
-            'code at https://github.com/bradtaniguchi/discord-bot-test'
-        )
-        .addFields(
-          { name: '\u200B', value: '\u200B' },
-          {
-            name: 'Commands',
-            value: 'Here are my currently available commands!'
-          },
-          {
-            name: '!eightball <optional string>',
-            value: 'Returns a response from a magic pool ball!'
-          },
-          //new command lines go below here.
+      const helpEmbed = {
+        color: "#0099FF",
+        title: "Bot Information",
+        description:
+          "Hello! I am a test bot created by bradtaniguchi and members of FreeCodeCamp.org to experiment with the process of building a Discord Bot. You can view my source code at https://github.com/bradtaniguchi/discord-bot-test",
+        fields: [],
+        footer: { text: "I am not affiliated with FreeCodeCamp in any way." },
+      };
 
-          //for spacing, leave this one at bottom.
-          { name: '\u200B', value: '\u200B' }
-        )
-        .setFooter('I am not affiliated with FreeCodeCamp in any way.');
+      fs.readdir(__dirname, (error, files) => {
+        if (error) {
+          console.error(error);
+        }
+        for (let i = 0; i < files.length; i++) {
+          let lookup = require(`./${files[i]}`);
+          if (lookup.prefix == undefined || lookup.description == undefined) {
+            continue;
+          } else {
+            let fieldObj = {
+              name: lookup.prefix.substring(0, 255),
+              value: lookup.description.substring(0, 1023),
+            };
+            helpEmbed.fields.push(fieldObj);
+          }
+        }
+      });
 
-      message.author.send(helpEmbed);
+      message.author.send({ embed: helpEmbed });
     } catch (error) {
       console.error(error);
     }
-  }
+  },
 };

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -23,9 +23,9 @@ module.exports = {
       footer: { text: 'I am not affiliated with FreeCodeCamp in any way.' }
     };
 
-    fsPromises.readdir(__dirname).then(async function(results) {
+    fsPromises.readdir(__dirname).then(async function (results) {
       console.log(results);
-      results.forEach(file => {
+      results.forEach((file) => {
         const filename = file;
         const lookup = require(`./${filename}`);
         if (lookup.prefix && lookup.description) {

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -25,7 +25,7 @@ module.exports = {
 
     const results = await fsPromises.readdir(__dirname);
     console.log(results);
-    results.forEach(file => {
+    results.forEach((file) => {
       const filename = file;
       const lookup = require(`./${filename}`);
       if (lookup.prefix && lookup.description) {

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,8 +1,8 @@
-const Discord = require("discord.js");
-const fs = require("fs");
+const Discord = require('discord.js');
+const fs = require('fs');
 module.exports = {
-  prefix: "!help",
-  description: "Get the commands currently available with this bot",
+  prefix: '!help',
+  description: 'Get the commands currently available with this bot',
   /**
    * @name help
    * Displays currently available commands.
@@ -15,12 +15,12 @@ module.exports = {
     //console.log("help", message);
     try {
       const helpEmbed = {
-        color: "#0099FF",
-        title: "Bot Information",
+        color: '#0099FF',
+        title: 'Bot Information',
         description:
-          "Hello! I am a test bot created by bradtaniguchi and members of FreeCodeCamp.org to experiment with the process of building a Discord Bot. You can view my source code at https://github.com/bradtaniguchi/discord-bot-test",
+          'Hello! I am a test bot created by bradtaniguchi and members of FreeCodeCamp.org to experiment with the process of building a Discord Bot. You can view my source code at https://github.com/bradtaniguchi/discord-bot-test',
         fields: [],
-        footer: { text: "I am not affiliated with FreeCodeCamp in any way." },
+        footer: { text: 'I am not affiliated with FreeCodeCamp in any way.' },
       };
 
       fs.readdir(__dirname, (error, files) => {
@@ -34,7 +34,7 @@ module.exports = {
           } else {
             let fieldObj = {
               name: lookup.prefix.substring(0, 255),
-              value: lookup.description.substring(0, 1023),
+              value: lookup.description.substring(0, 1023)
             };
             helpEmbed.fields.push(fieldObj);
           }
@@ -45,5 +45,5 @@ module.exports = {
     } catch (error) {
       console.error(error);
     }
-  },
+  }
 };

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -23,7 +23,7 @@ module.exports = {
       footer: { text: 'I am not affiliated with FreeCodeCamp in any way.' }
     };
 
-    fsPromises.readdir(__dirname).then(async function (results) {
+    const results = await fsPromises.readdir(__dirname)
       console.log(results);
       results.forEach((file) => {
         const filename = file;
@@ -37,6 +37,5 @@ module.exports = {
         }
       });
       await message.author.send({ embed: helpEmbed });
-    });
+    }
   }
-};

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -2,7 +2,7 @@ const Discord = require('discord.js');
 const fs = require('fs');
 const fsPromises = fs.promises;
 module.exports = {
-  prefix: '!help',
+  prefix: 'help',
   description: 'Get the commands currently available with this bot',
   /**
    * @name help

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -20,7 +20,7 @@ module.exports = {
         description:
           'Hello! I am a test bot created by bradtaniguchi and members of FreeCodeCamp.org to experiment with the process of building a Discord Bot. You can view my source code at https://github.com/bradtaniguchi/discord-bot-test',
         fields: [],
-        footer: { text: 'I am not affiliated with FreeCodeCamp in any way.' },
+        footer: { text: 'I am not affiliated with FreeCodeCamp in any way.' }
       };
 
       fs.readdir(__dirname, (error, files) => {

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -14,38 +14,29 @@ module.exports = {
 
   command: async function help(message) {
     //console.log("help", message);
-    try {
-      const helpEmbed = {
-        color: '#0099FF',
-        title: 'Bot Information',
-        description:
-          'Hello! I am a test bot created by bradtaniguchi and members of FreeCodeCamp.org to experiment with the process of building a Discord Bot. You can view my source code at https://github.com/bradtaniguchi/discord-bot-test',
-        fields: [],
-        footer: { text: 'I am not affiliated with FreeCodeCamp in any way.' }
-      };
+    const helpEmbed = {
+      color: '#0099FF',
+      title: 'Bot Information',
+      description:
+        'Hello! I am a test bot created by bradtaniguchi and members of FreeCodeCamp.org to experiment with the process of building a Discord Bot. You can view my source code at https://github.com/bradtaniguchi/discord-bot-test',
+      fields: [],
+      footer: { text: 'I am not affiliated with FreeCodeCamp in any way.' }
+    };
 
-      fsPromises
-        .readdir(__dirname)
-        .then((result) => {
-          for (let i = 0; i < result.length; i++) {
-            const filename = result[i];
-            const lookup = require(`./${filename}`);
-            if (!lookup.prefix || !lookup.description) {
-              continue;
-            } else {
-              const fieldObj = {
-                name: lookup.prefix.substring(0, 255),
-                value: lookup.description.substring(0, 1023)
-              };
-              helpEmbed.fields.push(fieldObj);
-            }
-          }
-        })
-        .catch((error) => console.log(error));
-
-      message.author.send({ embed: helpEmbed });
-    } catch (error) {
-      console.error(error);
-    }
+    fsPromises.readdir(__dirname).then(async function(results) {
+      console.log(results);
+      results.forEach(file => {
+        const filename = file;
+        const lookup = require(`./${filename}`);
+        if (lookup.prefix && lookup.description) {
+          const fieldObj = {
+            name: lookup.prefix.substring(0, 255),
+            value: lookup.description.substring(0, 1023)
+          };
+          helpEmbed.fields.push(fieldObj);
+        }
+      });
+      await message.author.send({ embed: helpEmbed });
+    });
   }
 };

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -23,19 +23,19 @@ module.exports = {
       footer: { text: 'I am not affiliated with FreeCodeCamp in any way.' }
     };
 
-    const results = await fsPromises.readdir(__dirname)
-      console.log(results);
-      results.forEach((file) => {
-        const filename = file;
-        const lookup = require(`./${filename}`);
-        if (lookup.prefix && lookup.description) {
-          const fieldObj = {
-            name: lookup.prefix.substring(0, 255),
-            value: lookup.description.substring(0, 1023)
-          };
-          helpEmbed.fields.push(fieldObj);
-        }
-      });
-      await message.author.send({ embed: helpEmbed });
-    }
+    const results = await fsPromises.readdir(__dirname);
+    console.log(results);
+    results.forEach(file => {
+      const filename = file;
+      const lookup = require(`./${filename}`);
+      if (lookup.prefix && lookup.description) {
+        const fieldObj = {
+          name: lookup.prefix.substring(0, 255),
+          value: lookup.description.substring(0, 1023)
+        };
+        helpEmbed.fields.push(fieldObj);
+      }
+    });
+    await message.author.send({ embed: helpEmbed });
   }
+};

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -28,7 +28,8 @@ module.exports = {
           console.error(error);
         }
         for (let i = 0; i < files.length; i++) {
-          let lookup = require(`./${files[i]}`);
+          let filename = files[i];
+          let lookup = require(`./${filename}`);
           if (lookup.prefix == undefined || lookup.description == undefined) {
             continue;
           } else {


### PR DESCRIPTION
Help command will now do the following:

- [x] Automatically scan the files in the commands directory for commands.
- [x] Create embed with fields, each containing a command's prefix and description.
- [x] Skip any file in the commands directory that is missing either the prefix or description property. 
- [x] Trim the name and value of each embed field to ensure it does not exceed the limits. 

Closes #22 