### PR TITLE
Add feature flag for deleted messages logging

### DIFF
--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -93,7 +93,7 @@ module.exports = function bootstrap({ client, config }) {
   client.on('messageDelete', function (message) {
     //change channel name to match server configuration
     const logChannel = message.guild.channels.cache.find(
-      (channel) => channel.name == 'moderation-activity'
+      (channel) => channel.name == config.LOG_MSG_CHANNEL
     );
     const deleteEmbed = new Discord.MessageEmbed()
       .setTitle('A message was deleted.')
@@ -115,7 +115,6 @@ module.exports = function bootstrap({ client, config }) {
       );
     if (!logChannel) {
       console.error('logging channel not found');
-      message.channel.send(deleteEmbed);
       return;
     }
     logChannel.send(deleteEmbed);

--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -93,7 +93,7 @@ module.exports = function bootstrap({ client, config }) {
   client.on('messageDelete', function (message) {
     //change channel name to match server configuration
     const logChannel = message.guild.channels.cache.find(
-      (channel) => channel.name == config.LOG_MSG_CHANNEL
+      (channel) => channel.name === config.LOG_MSG_CHANNEL
     );
     const deleteEmbed = new Discord.MessageEmbed()
       .setTitle('A message was deleted.')

--- a/src/config/get-config.js
+++ b/src/config/get-config.js
@@ -42,7 +42,7 @@ module.exports = function getConfig() {
      * If not given, or if the channel is not found
      * the log will not be generated.
      */
-    LOG_MSG_CHANNEL: process.env.LOG_MSG_CHANNEL === 'true',
+    LOG_MSG_CHANNEL: process.env.LOG_MSG_CHANNEL || 'moderation-activity',
     /**
      * The port to "listen" for liveness checks.
      * Defaults to 8080

--- a/src/config/get-config.js
+++ b/src/config/get-config.js
@@ -38,6 +38,12 @@ module.exports = function getConfig() {
      */
     LEAVE_MSG_CHANNEL: process.env.LEAVE_MSG_CHANNEL === 'true',
     /**
+     * The name of the channel to log deleted messages to.
+     * If not given, or if the channel is not found
+     * the log will not be generated.
+     */
+    LOG_MSG_CHANNEL: process.env.LOG_MSG_CHANNEL === 'true',
+    /**
      * The port to "listen" for liveness checks.
      * Defaults to 8080
      */


### PR DESCRIPTION
Okay, I don't have a local version of your bot to test this on. But I followed the example for the depart messages (except the secret .env file doesn't exist so I can't set that up.) and I believe I've configured the logging to call the variable correctly.
Also changed it to log nothing (just throw a console message) if the channel doesn't exist.

Closes #52 