### PR TITLE
Add attachment filtering

### DIFF
--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -121,7 +121,10 @@ module.exports = function bootstrap({ client, config }) {
   });
 
   client.on('message', (message) => {
-    if (message.attachments.array().length > 0 && !message.attachments.array()[0].height) {
+    if (
+      message.attachments.array().length > 0 &&
+      !message.attachments.array()[0].height
+    ) {
       message.delete();
       message.channel.send(
         'Please do not upload any files other than images or videos. For large blocks of code, use CodePen or PasteBin.'

--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -121,6 +121,12 @@ module.exports = function bootstrap({ client, config }) {
   });
 
   client.on('message', (message) => {
+    if (message.attachments.array().length > 0) {
+      if (!message.attachments.array()[0].height) {
+        message.delete();
+        message.channel.send('Please do not upload any files other than images or videos. For large blocks of code, use CodePen or PasteBin.');
+      }
+    }
     if (message.content.startsWith(config.PREFIX)) {
       // Get command after prefix
       const commandArgument = message.content.split(' ')[1];

--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -121,13 +121,11 @@ module.exports = function bootstrap({ client, config }) {
   });
 
   client.on('message', (message) => {
-    if (message.attachments.array().length > 0) {
-      if (!message.attachments.array()[0].height) {
-        message.delete();
-        message.channel.send(
-          'Please do not upload any files other than images or videos. For large blocks of code, use CodePen or PasteBin.'
-        );
-      }
+    if (message.attachments.array().length > 0 && !message.attachments.array()[0].height) {
+      message.delete();
+      message.channel.send(
+        'Please do not upload any files other than images or videos. For large blocks of code, use CodePen or PasteBin.'
+      );
     }
     if (message.content.startsWith(config.PREFIX)) {
       // Get command after prefix

--- a/src/commands/bootstrap.js
+++ b/src/commands/bootstrap.js
@@ -124,7 +124,9 @@ module.exports = function bootstrap({ client, config }) {
     if (message.attachments.array().length > 0) {
       if (!message.attachments.array()[0].height) {
         message.delete();
-        message.channel.send('Please do not upload any files other than images or videos. For large blocks of code, use CodePen or PasteBin.');
+        message.channel.send(
+          'Please do not upload any files other than images or videos. For large blocks of code, use CodePen or PasteBin.'
+        );
       }
     }
     if (message.content.startsWith(config.PREFIX)) {


### PR DESCRIPTION
Removes any message containing an attachment that is not an image or video, to prevent sending harmful code files.