### PR TITLE
Fix/help

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -37,5 +37,6 @@ module.exports = {
       }
     });
     await message.author.send({ embed: helpEmbed });
+    await message.channel.send('Help message sent!');
   }
 };

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -37,6 +37,6 @@ module.exports = {
       }
     });
     await message.author.send({ embed: helpEmbed });
-    await message.channel.send('Help message sent!');
+    message.channel.send('Help message sent!');
   }
 };


### PR DESCRIPTION
Because the bot sends the help message as a DM, it remains silent in the channel and appears unresponsive to other users. I've added a short confirmation to be sent to the command channel to show that the bot has received the command.