### PR TITLE
Verbose config was incorrect

### DIFF
--- a/src/config/get-config.ts
+++ b/src/config/get-config.ts
@@ -71,7 +71,7 @@ export function getConfig(): Config {
   return {
     TOKEN: process.env.TOKEN || '',
     PREFIX: process.env.PREFIX || '!FCC',
-    VERBOSE: process.env.PREFIX === 'true',
+    VERBOSE: process.env.VERBOSE === 'true',
     BOT_ROLE: process.env.BOT_ROLE || '',
     WELCOME_DM: process.env.WELCOME_DM === 'true',
     LEAVE_MSG_CHANNEL: process.env.LEAVE_MSG_CHANNEL || '',


### PR DESCRIPTION
The `VERBOSE` config setting was looking for `PREFIX` to be true. Changed it to look for `VERBOSE` to be true.