### PR TITLE
Getting Commit Hash Locally and When Deployed on Heroku Closes (#59)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2152,6 +2152,24 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "requires": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -4898,6 +4916,15 @@
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5581,6 +5608,11 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -6184,8 +6216,7 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -6329,6 +6360,11 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -7506,6 +7542,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yaml": {
       "version": "1.9.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3309,6 +3309,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "git-repo-info": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-2.1.1.tgz",
+      "integrity": "sha512-8aCohiDo4jwjOwma4FmYFd3i97urZulL8XL24nIPxuE+GZnfsAyy/g2Shqx6OjUiFKUXZM+Yy+KHnOmmA3FVcg=="
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "discord.js": "^12.2.0",
     "dotenv": "^8.2.0",
-    "editorconfig": "^0.15.3",
     "express": "^4.17.1",
     "highlight.js": "^10.0.3",
     "prettier": "^2.0.5",
@@ -26,7 +25,8 @@
     "jest": "^26.0.1",
     "lint-staged": "^10.2.2",
     "nodemon": "^2.0.3",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "editorconfig": "^0.15.3"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "discord.js": "^12.2.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "git-repo-info": "^2.1.1",
     "highlight.js": "^10.0.3",
     "node-fetch": "^2.6.0",
     "prettier": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "discord.js": "^12.2.0",
     "dotenv": "^8.2.0",
+    "editorconfig": "^0.15.3",
     "express": "^4.17.1",
     "highlight.js": "^10.0.3",
     "prettier": "^2.0.5",

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -1,5 +1,9 @@
 import { getUpTime } from '../utilities/get-up-time';
 import { CommandDef } from './command-def';
+import getRepoInfo from 'git-repo-info';
+const info = getRepoInfo();
+import dotenv from 'dotenv';
+dotenv.config();
 
 export const stats: CommandDef = {
   prefix: 'stats',
@@ -12,6 +16,13 @@ export const stats: CommandDef = {
   command: (message, client): void => {
     try {
       const uptime = getUpTime(client);
+
+      // If run locally, it will get the commit hash using a different approach
+      const versionHash = process.env.SOURCE_VERSION;
+      const commitHash =
+        versionHash == undefined
+          ? info.abbreviatedSha
+          : versionHash.slice(0, 10);
 
       const statsEmbed = {
         color: '#0099FF',
@@ -29,6 +40,10 @@ export const stats: CommandDef = {
           {
             name: 'Bot Online Time',
             value: 'Wake Time from JSON file'
+          },
+          {
+            name: 'Version',
+            value: `[${commitHash}](https://github.com/bradtaniguchi/discord-bot-test/commit/${commitHash})`
           },
           {
             name: 'Created on',

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -2,8 +2,6 @@ import { getUpTime } from '../utilities/get-up-time';
 import { CommandDef } from './command-def';
 import getRepoInfo from 'git-repo-info';
 const info = getRepoInfo();
-import dotenv from 'dotenv';
-dotenv.config();
 
 export const stats: CommandDef = {
   prefix: 'stats',
@@ -18,11 +16,8 @@ export const stats: CommandDef = {
       const uptime = getUpTime(client);
 
       // If run locally, it will get the commit hash using a different approach
-      const versionHash = process.env.SOURCE_VERSION;
       const commitHash =
-        versionHash == undefined
-          ? info.abbreviatedSha
-          : versionHash.slice(0, 10);
+        process.env.SOURCE_VERSION?.slice(0, 10) || info.abbreviatedSha;
 
       const statsEmbed = {
         color: '#0099FF',


### PR DESCRIPTION
If `heroku buildpacks:add https://github.com/ianpurvis/heroku-buildpack-version -a [app-name]` was successfully added by nhcarrigan to the bot app, the variable should be available to carry when deployed. If the user is using the bot locally, then it will get the commit hash locally. 