### PR TITLE
Uptime and Wake Time Closes (#59)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1048,7 +1048,8 @@
     "@types/luxon": {
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-1.24.1.tgz",
-      "integrity": "sha512-t93qL4l3PRxy4qQkXwiPS6qjIt7S6o90XMuCfvYDgIAQJvgSBni5qVPxkhGYPnZZPS9ASHOTeCZXRNmdiHHHcg=="
+      "integrity": "sha512-t93qL4l3PRxy4qQkXwiPS6qjIt7S6o90XMuCfvYDgIAQJvgSBni5qVPxkhGYPnZZPS9ASHOTeCZXRNmdiHHHcg==",
+      "dev": true
     },
     "@types/mime": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1045,6 +1045,11 @@
       "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
       "dev": true
     },
+    "@types/luxon": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-1.24.1.tgz",
+      "integrity": "sha512-t93qL4l3PRxy4qQkXwiPS6qjIt7S6o90XMuCfvYDgIAQJvgSBni5qVPxkhGYPnZZPS9ASHOTeCZXRNmdiHHHcg=="
+    },
     "@types/mime": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
@@ -5225,6 +5230,11 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "luxon": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.24.1.tgz",
+      "integrity": "sha512-CgnIMKAWT0ghcuWFfCWBnWGOddM0zu6c4wZAWmD0NN7MZTnro0+833DF6tJep+xlxRPg4KtsYEHYLfTMBQKwYg=="
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2152,6 +2152,24 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "requires": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -4898,6 +4916,15 @@
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5581,6 +5608,11 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -6184,8 +6216,7 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -6329,6 +6360,11 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -7506,6 +7542,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yaml": {
       "version": "1.9.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3309,6 +3309,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "git-repo-info": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-2.1.1.tgz",
+      "integrity": "sha512-8aCohiDo4jwjOwma4FmYFd3i97urZulL8XL24nIPxuE+GZnfsAyy/g2Shqx6OjUiFKUXZM+Yy+KHnOmmA3FVcg=="
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@types/luxon": "^1.24.1",
     "discord.js": "^12.2.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
@@ -28,6 +27,7 @@
     "@types/express": "^4.17.6",
     "@types/highlightjs": "^9.12.0",
     "@types/jest": "^26.0.0",
+    "@types/luxon": "^1.24.1",
     "@types/node-fetch": "^2.5.7",
     "@types/prettier": "^2.0.1",
     "@types/strip-ansi": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "discord.js": "^12.2.0",
     "dotenv": "^8.2.0",
-    "editorconfig": "^0.15.3",
     "express": "^4.17.1",
     "highlight.js": "^10.0.3",
     "prettier": "^2.0.5",
@@ -26,7 +25,8 @@
     "jest": "^26.0.1",
     "lint-staged": "^10.2.2",
     "nodemon": "^2.0.3",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "editorconfig": "^0.15.3"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "discord.js": "^12.2.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "git-repo-info": "^2.1.1",
     "highlight.js": "^10.0.3",
     "node-fetch": "^2.6.0",
     "prettier": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@types/luxon": "^1.24.1",
     "discord.js": "^12.2.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "git-repo-info": "^2.1.1",
     "highlight.js": "^10.0.3",
+    "luxon": "^1.24.1",
     "node-fetch": "^2.6.0",
     "prettier": "^2.0.5",
     "strip-ansi": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "discord.js": "^12.2.0",
     "dotenv": "^8.2.0",
+    "editorconfig": "^0.15.3",
     "express": "^4.17.1",
     "highlight.js": "^10.0.3",
     "prettier": "^2.0.5",

--- a/src/commands/command-def.ts
+++ b/src/commands/command-def.ts
@@ -1,4 +1,13 @@
 import { Message, Client } from 'discord.js';
+import { Config } from '../config/get-config';
+
+/**
+ * Extra arguments passed to each command.
+ */
+export interface CommandDefArgs {
+  client: Client;
+  config: Config;
+}
 
 /**
  * Definition for a "prefix" command
@@ -6,5 +15,5 @@ import { Message, Client } from 'discord.js';
 export interface CommandDef {
   prefix: string;
   description: string;
-  command: (message: Message, client: Client) => void;
+  command: (message: Message, args: CommandDefArgs) => void;
 }

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -1,6 +1,5 @@
 import { getUpTime } from '../utilities/get-up-time';
 import { CommandDef } from './command-def';
-import { getConfig } from '../config/get-config';
 import getRepoInfo from 'git-repo-info';
 const info = getRepoInfo();
 
@@ -12,7 +11,7 @@ export const stats: CommandDef = {
    * Displays the server stats.
    * @param message the message provided by discord
    */
-  command: (message, client): void => {
+  command: (message, { client, config }): void => {
     try {
       const uptime = getUpTime(client);
 
@@ -35,7 +34,7 @@ export const stats: CommandDef = {
           },
           {
             name: 'Bot Online Time',
-            value: getConfig().ONLINE_AT
+            value: config.ONLINE_AT
           },
           {
             name: 'Version',

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -1,5 +1,6 @@
 import { getUpTime } from '../utilities/get-up-time';
 import { CommandDef } from './command-def';
+import { onlineAt } from '../index';
 import getRepoInfo from 'git-repo-info';
 const info = getRepoInfo();
 
@@ -18,6 +19,7 @@ export const stats: CommandDef = {
       // If run locally, it will get the commit hash using a different approach
       const commitHash =
         process.env.SOURCE_VERSION?.slice(0, 10) || info.abbreviatedSha;
+      const tzSearchQuery: string = onlineAt.replace(/ /g, '%20');
 
       const statsEmbed = {
         color: '#0099FF',
@@ -34,11 +36,7 @@ export const stats: CommandDef = {
           },
           {
             name: 'Bot Online Time',
-            value: `[${onlineAt}](https://google.com/search?q=${tzSearch})`
-          },
-          {
-            name: 'Version',
-            value: `[${commitHash}](https://github.com/bradtaniguchi/discord-bot-test/commit/${commitHash})`
+            value: `[${onlineAt}](https://google.com/search?q=${tzSearchQuery})`
           },
           {
             name: 'Version',

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -1,5 +1,9 @@
 import { getUpTime } from '../utilities/get-up-time';
 import { CommandDef } from './command-def';
+import getRepoInfo from 'git-repo-info';
+const info = getRepoInfo();
+import dotenv from 'dotenv';
+dotenv.config();
 
 export const stats: CommandDef = {
   prefix: 'stats',
@@ -12,6 +16,13 @@ export const stats: CommandDef = {
   command: (message, client): void => {
     try {
       const uptime = getUpTime(client);
+
+      // If run locally, it will get the commit hash using a different approach
+      const versionHash = process.env.SOURCE_VERSION;
+      const commitHash =
+        versionHash == undefined
+          ? info.abbreviatedSha
+          : versionHash.slice(0, 10);
 
       const statsEmbed = {
         color: '#0099FF',
@@ -29,6 +40,10 @@ export const stats: CommandDef = {
           {
             name: 'Bot Online Time',
             value: 'Wake Time from JSON file'
+          },
+          {
+            name: 'Version',
+            value: `[${commitHash}](https://github.com/bradtaniguchi/discord-bot-test/commit/${commitHash})`
           },
           {
             name: 'Created on',

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -1,5 +1,6 @@
 import { getUpTime } from '../utilities/get-up-time';
 import { CommandDef } from './command-def';
+import { getConfig } from '../config/get-config';
 import getRepoInfo from 'git-repo-info';
 const info = getRepoInfo();
 
@@ -34,11 +35,7 @@ export const stats: CommandDef = {
           },
           {
             name: 'Bot Online Time',
-            value: `[${onlineAt}](https://google.com/search?q=${tzSearch})`
-          },
-          {
-            name: 'Version',
-            value: `[${commitHash}](https://github.com/bradtaniguchi/discord-bot-test/commit/${commitHash})`
+            value: getConfig().ONLINE_AT
           },
           {
             name: 'Version',

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -19,7 +19,6 @@ export const stats: CommandDef = {
       // If run locally, it will get the commit hash using a different approach
       const commitHash =
         process.env.SOURCE_VERSION?.slice(0, 10) || info.abbreviatedSha;
-      const tzSearchQuery: string = onlineAt.replace(/ /g, '%20');
 
       const statsEmbed = {
         color: '#0099FF',

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -1,5 +1,6 @@
 import { getUpTime } from '../utilities/get-up-time';
 import { CommandDef } from './command-def';
+import { onlineAt } from '../index';
 import getRepoInfo from 'git-repo-info';
 const info = getRepoInfo();
 
@@ -18,6 +19,7 @@ export const stats: CommandDef = {
       // If run locally, it will get the commit hash using a different approach
       const commitHash =
         process.env.SOURCE_VERSION?.slice(0, 10) || info.abbreviatedSha;
+      const tzSearch = onlineAt.replace(/ /g, '%20');
 
       const statsEmbed = {
         color: '#0099FF',
@@ -34,7 +36,7 @@ export const stats: CommandDef = {
           },
           {
             name: 'Bot Online Time',
-            value: 'Wake Time from JSON file'
+            value: `[${onlineAt}](https://google.com/search?q=${tzSearch})`
           },
           {
             name: 'Version',

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -2,8 +2,6 @@ import { getUpTime } from '../utilities/get-up-time';
 import { CommandDef } from './command-def';
 import getRepoInfo from 'git-repo-info';
 const info = getRepoInfo();
-import dotenv from 'dotenv';
-dotenv.config();
 
 export const stats: CommandDef = {
   prefix: 'stats',
@@ -18,11 +16,8 @@ export const stats: CommandDef = {
       const uptime = getUpTime(client);
 
       // If run locally, it will get the commit hash using a different approach
-      const versionHash = process.env.SOURCE_VERSION;
       const commitHash =
-        versionHash == undefined
-          ? info.abbreviatedSha
-          : versionHash.slice(0, 10);
+        process.env.SOURCE_VERSION?.slice(0, 10) || info.abbreviatedSha;
 
       const statsEmbed = {
         color: '#0099FF',

--- a/src/config/get-config.ts
+++ b/src/config/get-config.ts
@@ -1,3 +1,5 @@
+import { getBotOnlineAt } from '../utilities/bot-online-time';
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('dotenv').config();
 
@@ -60,6 +62,11 @@ export interface Config {
    * Defaults to 8080
    */
   PORT: number | string;
+  /**
+   * Get the bot Start Time/ Online Time in a
+   * [HH:MM:SS PM/AM TZ] format
+   */
+  ONLINE_AT: string;
 }
 /**
  * @name getConfig
@@ -78,6 +85,7 @@ export function getConfig(): Config {
     LOG_MSG_CHANNEL: process.env.LOG_MSG_CHANNEL || 'moderation-activity',
     SUSPEND_ROLE: process.env.SUSPEND_ROLE || '',
     SUSPEND_CATEGORY: process.env.SUSPEND_CATEGORY || '',
-    PORT: process.env.PORT || 8080
+    PORT: process.env.PORT || 8080,
+    ONLINE_AT: getBotOnlineAt() || ''
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { validateConfig } from './config/validate-config';
 import { getBotOnlineAt } from './utilities/bot-online-time';
 const expressApp = express();
 const client = new Client({ partials: ['MESSAGE', 'CHANNEL', 'REACTION'] });
+let onlineAt: string;
 
 (async () => {
   try {
@@ -27,7 +28,7 @@ const client = new Client({ partials: ['MESSAGE', 'CHANNEL', 'REACTION'] });
     client.once('ready', () => {
       // This variable will be the variable put inside the JSON file.
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const onlineAt = getBotOnlineAt();
+      onlineAt = getBotOnlineAt();
       console.log('Discord ready!');
     });
     client.login(config.TOKEN);
@@ -45,3 +46,5 @@ const client = new Client({ partials: ['MESSAGE', 'CHANNEL', 'REACTION'] });
     process.exit(1);
   }
 })();
+
+export { onlineAt };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,9 @@ import express from 'express';
 import { bootstrap } from './commands/bootstrap';
 import { getConfig } from './config/get-config';
 import { validateConfig } from './config/validate-config';
-import { getBotOnlineAt } from './utilities/bot-online-time';
+
 const expressApp = express();
 const client = new Client({ partials: ['MESSAGE', 'CHANNEL', 'REACTION'] });
-let onlineAt: string;
 
 (async () => {
   try {
@@ -26,9 +25,6 @@ let onlineAt: string;
     }
 
     client.once('ready', () => {
-      // This variable will be the variable put inside the JSON file.
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      onlineAt = getBotOnlineAt();
       console.log('Discord ready!');
     });
     client.login(config.TOKEN);
@@ -46,5 +42,3 @@ let onlineAt: string;
     process.exit(1);
   }
 })();
-
-export { onlineAt };

--- a/src/utilities/bot-online-time.ts
+++ b/src/utilities/bot-online-time.ts
@@ -4,8 +4,10 @@ export function getBotOnlineAt(): string {
   const mins =
     date.getMinutes() < 10 ? `0${date.getMinutes()}` : date.getMinutes();
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const timeZ = /\((.*)\)/.exec(new Date().toString())![1];
-  const tz = timeZ.match(/[A-Z]+/g)?.join('');
+  const tz = /\((.*)\)/
+    .exec(new Date().toString())![1]
+    .match(/[A-Z]/g)
+    ?.join('');
   const am_pm = hour >= 12 ? 'PM' : 'AM';
 
   return `${hour}:${mins} ${am_pm} ${tz}`;

--- a/src/utilities/bot-online-time.ts
+++ b/src/utilities/bot-online-time.ts
@@ -4,7 +4,8 @@ export function getBotOnlineAt(): string {
   const mins =
     date.getMinutes() < 10 ? `0${date.getMinutes()}` : date.getMinutes();
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const tz = /\((.*)\)/.exec(new Date().toString())![1];
+  const timeZ = /\((.*)\)/.exec(new Date().toString())![1];
+  const tz = timeZ.match(/[A-Z]+/g)?.join('');
   const am_pm = hour >= 12 ? 'PM' : 'AM';
 
   return `${hour}:${mins} ${am_pm} ${tz}`;

--- a/src/utilities/bot-online-time.ts
+++ b/src/utilities/bot-online-time.ts
@@ -1,12 +1,8 @@
-export function getBotOnlineAt(): string {
-  const date = new Date();
-  const hour = date.getHours() < 10 ? `0${date.getHours()}` : date.getHours();
-  const mins =
-    date.getMinutes() < 10 ? `0${date.getMinutes()}` : date.getMinutes();
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const timeZ = /\((.*)\)/.exec(new Date().toString())![1];
-  const tz = timeZ.match(/[A-Z]+/g)?.join('');
-  const am_pm = hour >= 12 ? 'PM' : 'AM';
+import { DateTime } from 'luxon';
 
-  return `${hour}:${mins} ${am_pm} ${tz}`;
+export function getBotOnlineAt(): string {
+  const dt = DateTime.local();
+  const format = dt.toLocaleString(DateTime.TIME_WITH_SHORT_OFFSET);
+
+  return format;
 }


### PR DESCRIPTION
This will close #59 
- [x] Uptime will display the time the bot has been up for, `[DD] [HH] [MM] [SS]` format.
- [x] Bot Wake Up Time will show the time the bot was up at. `[HH:MM] [AM/PM] [TimeZone]` format. It is also linked to a google search for the time to show the relative time to the user's area. 

It turns out we didn't need the JSON file after all. Just a simple export from the start. The Wake Time will open up a google search to their relative location since the bot will only give the time from where it's located. So I just rigged up a google search query and let Google do the job for me 😆. 
Here's an example: 
![image](https://user-images.githubusercontent.com/45566099/86309480-d4315b80-bbe9-11ea-8415-16257bffea61.png)

**Note: Ignore most of the commits, most of them are me Trying to merge the upstream to my master**
