### PR TITLE
Update command-def to include config and client

### DIFF
--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -157,7 +157,7 @@ export function bootstrap({
       }
       // Execute command
       try {
-        commands.get(commandArgument)?.command(message, client);
+        commands.get(commandArgument)?.command(message, { client, config });
       } catch (error) {
         console.error(error);
         message.reply('there was an error trying to execute that command!');

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -1,9 +1,5 @@
 import { CommandDef } from './command-def';
-import { getConfig } from '../config/get-config';
 import { TextChannel, MessageEmbed } from 'discord.js';
-
-// TODO: will be passed as command arg
-const config = getConfig();
 
 export const closeCommand: CommandDef = {
   prefix: 'close',
@@ -11,7 +7,7 @@ export const closeCommand: CommandDef = {
     'Closes the channel. This command requires admin privileges, ' +
     'and will only work on the automatically created "suspended" channels.' +
     ' Include the user if you want to remove the suspended role.',
-  command: async (message): Promise<void> => {
+  command: async (message, { config }): Promise<void> => {
     try {
       const target = message.channel as TextChannel;
       //check for log channel

--- a/src/commands/command-def.ts
+++ b/src/commands/command-def.ts
@@ -1,4 +1,13 @@
 import { Message, Client } from 'discord.js';
+import { Config } from '../config/get-config';
+
+/**
+ * Extra arguments passed to each command.
+ */
+export interface CommandDefArgs {
+  client: Client;
+  config: Config;
+}
 
 /**
  * Definition for a "prefix" command
@@ -6,5 +15,5 @@ import { Message, Client } from 'discord.js';
 export interface CommandDef {
   prefix: string;
   description: string;
-  command: (message: Message, client: Client) => void;
+  command: (message: Message, args: CommandDefArgs) => void;
 }

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -11,7 +11,7 @@ export const stats: CommandDef = {
    * Displays the server stats.
    * @param message the message provided by discord
    */
-  command: (message, client): void => {
+  command: (message, { client }): void => {
     try {
       const uptime = getUpTime(client);
 

--- a/src/commands/suspend.ts
+++ b/src/commands/suspend.ts
@@ -1,16 +1,12 @@
-import { getConfig } from '../config/get-config';
 import { CommandDef } from './command-def';
 import { MessageEmbed, TextChannel } from 'discord.js';
-
-// TODO: will be passed as command arg
-const config = getConfig();
 
 export const suspendCommand: CommandDef = {
   prefix: 'suspend',
   description:
     'Suspends a user for the given reason. This command is only available to admins. ' +
     'Use the format "suspend <usertag> <reason>"',
-  command: async (message): Promise<void> => {
+  command: async (message, { config }): Promise<void> => {
     try {
       //check for appropriate permissions
       if (!message.member?.hasPermission('KICK_MEMBERS')) {


### PR DESCRIPTION
- Update the command-def interface to include the single passed config. This should fix issues where getConfig is ran multiple times.

