### PR TITLE
Feature/update mod links

### DIFF
--- a/src/commands/mod.ts
+++ b/src/commands/mod.ts
@@ -22,6 +22,11 @@ export const mod: CommandDef = {
       {
         name: 'News Contributing',
         value: 'https://www.freecodecamp.org/news/developer-news-style-guide/'
+      },
+      {
+        name: 'Pull Request Reviews',
+        value:
+          '[PRs Ready for Review](https://github.com/freeCodeCamp/freeCodeCamp/pulls?q=is%3Aopen+is%3Apr+-label%3A%22status%3A+blocked%22+-label%3A%22status%3A+merge+conflict%22+status%3Asuccess+draft%3Afalse)'
       }
     );
     message.channel.send(modEmbed);


### PR DESCRIPTION
**Description:**

This PR adds a link to the `mod` command for the freeCodeCamp PRs ready to review - the link automatically applies filters to show only the pull requests that are not draft, not a merge conflict, not blocked, and pass all CI checks. Shoutout to Mrugesh for the link. 
<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
