### PR TITLE
Feature/revamp suspend command

### DIFF
--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -12,6 +12,10 @@ export const closeCommand: CommandDef = {
   usage: 'close [accepted | denied] [user]',
   command: async (message, { config }): Promise<void> => {
     try {
+      if (!message.member?.hasPermission('MANAGE_CHANNELS'))
+        return console.log(
+          `${message.author.username} did not have the correct permissions.`
+        );
       const flag = message.content.split(' ')[2];
       if (flag !== 'accepted' && flag !== 'denied')
         return console.log('invalid paramater');

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -9,9 +9,12 @@ export const closeCommand: CommandDef = {
     and will only work on the automatically created "suspended" channels.
     Mentioning user with the command will remove the suspended role from the user.
   `,
-  usage: 'close [user]',
+  usage: 'close [accepted | denied] [user]',
   command: async (message, { config }): Promise<void> => {
     try {
+      const flag = message.content.split(' ')[2];
+      if (flag !== 'accepted' && flag !== 'denied')
+        return console.log('invalid paramater');
       const target = message.channel as TextChannel;
       //check for log channel
       const log = message.guild?.channels.cache.find(
@@ -31,7 +34,7 @@ export const closeCommand: CommandDef = {
       }
 
       let status = 'The appeal was not approved.';
-      if (message.mentions.members?.first()) {
+      if (message.mentions.members?.first() && flag === 'accepted') {
         const suspend = message.guild?.roles.cache.find(
           (role) => role.name == config.SUSPEND_ROLE
         );

--- a/src/commands/suspend.ts
+++ b/src/commands/suspend.ts
@@ -68,7 +68,7 @@ export const suspendCommand: CommandDef = {
       }
       const reasonArg = msgArguments.slice(3, msgArguments.length);
       //check for reason provided, if none then create one.
-      const reason = reasonArg.join(' ') || 'No reason provided';
+      const reason = reasonArg.join(' ') || 'violation of the rules';
       //logging embed
       const restrictEmbed = new MessageEmbed()
         .setColor('#FF0000')
@@ -95,28 +95,39 @@ export const suspendCommand: CommandDef = {
         permissionOverwrites: [
           {
             id: user.id,
-            allow: ['VIEW_CHANNEL', 'READ_MESSAGE_HISTORY', 'SEND_MESSAGES']
+            allow: ['VIEW_CHANNEL', 'READ_MESSAGE_HISTORY', 'SEND_MESSAGES'],
+            deny: ['CREATE_INSTANT_INVITE']
           },
           {
             id: message.guild.id,
-            deny: ['VIEW_CHANNEL', 'READ_MESSAGE_HISTORY', 'SEND_MESSAGES']
+            deny: [
+              'VIEW_CHANNEL',
+              'READ_MESSAGE_HISTORY',
+              'SEND_MESSAGES',
+              'CREATE_INSTANT_INVITE'
+            ]
           },
           {
             id: bot,
-            allow: ['VIEW_CHANNEL', 'READ_MESSAGE_HISTORY', 'SEND_MESSAGES']
+            allow: ['VIEW_CHANNEL', 'READ_MESSAGE_HISTORY', 'SEND_MESSAGES'],
+            deny: ['CREATE_INSTANT_INVITE']
           },
           {
             id: modRole,
-            allow: ['VIEW_CHANNEL', 'READ_MESSAGE_HISTORY', 'SEND_MESSAGES']
+            allow: ['VIEW_CHANNEL', 'READ_MESSAGE_HISTORY', 'SEND_MESSAGES'],
+            deny: ['CREATE_INSTANT_INVITE']
           }
         ],
         parent: category
       });
       await suspendChannel?.send(
-        `This channel has been created for ${user} to discuss their suspension from the server. Once the discussion has concluded, an admin may use the \`close\` command to automatically close this channel.`
-      );
-      await user.send(
-        'You have been suspended for violating our Code of Conduct. A channel has been created in the server for you to discuss this with the moderation team.'
+        `This is a standard message notifying ${user} that you have been suspended from freeCodeCamp's Discord for ${reason}.
+
+       This channel has been created for you to appeal this decision. In order to appeal the decision, you must complete the following steps:
+
+        1. Read our Code of Conduct: https://code-of-conduct.freecodecamp.org/
+        2. Confirm in this channel that you have read it.
+        3. Explain in this channel why you feel you should be un-suspended.`
       );
       if (config.MONGO_URI) {
         const userSuspend: UserSuspend | null = await userSuspendModel.findOne({

--- a/src/commands/suspend.ts
+++ b/src/commands/suspend.ts
@@ -127,7 +127,9 @@ export const suspendCommand: CommandDef = {
 
         1. Read our Code of Conduct: https://code-of-conduct.freecodecamp.org/
         2. Confirm in this channel that you have read it.
-        3. Explain in this channel why you feel you should be un-suspended.`
+        3. Explain in this channel why you feel you should be un-suspended.
+
+        /cc ${modRole}`
       );
       if (config.MONGO_URI) {
         const userSuspend: UserSuspend | null = await userSuspendModel.findOne({


### PR DESCRIPTION
**Description:**
This PR tackles a few things:

Suspend command:
1. Explicitly deny the `create invite` permission for everyone in the automatically created channel. 
2. Remove the DM sent to the user on suspension. 
3. Use the FCC template for the initial message in the suspended channel.
4. Include the username and the reason in that message.
5. That message also tags the moderator role. 

Close command:
1. Now requires an additional parameter of "accepted" or "denied". Will fail on any other value. 
2. "Accepted" closes the channel and removes the suspension. "Denied" only closes the channel.
3. Now requires the `manage channels` permission. 

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

TODO:
~~1. Close command should require "manage channels" permission~~
~~2. Close command should take "accepted" | "denied" to determine whether to remove suspension or not.~~