### PR TITLE
Feat/152/suspend user log

### DIFF
--- a/src/APIs/mongo-suspend.ts
+++ b/src/APIs/mongo-suspend.ts
@@ -2,12 +2,22 @@ import { Document, Schema, model } from 'mongoose';
 
 export interface UserSuspend extends Document {
   userId: string;
-  suspended: boolean;
+  currentUsername: string;
+  currentNickname: string;
+  suspended: ReasonInt[];
 }
 
 export const userSuspendSchema = new Schema({
   userId: String,
-  suspended: Boolean
+  currentUsername: String,
+  currentNickname: String,
+  suspended: Array
 });
+
+interface ReasonInt {
+  date: string;
+  mod: string;
+  reason: string;
+}
 
 export const userSuspendModel = model<UserSuspend>('user', userSuspendSchema);

--- a/src/commands/suspend.ts
+++ b/src/commands/suspend.ts
@@ -139,11 +139,27 @@ export const suspendCommand: CommandDef = {
           await message.author.send(
             `Hello! It looks like ${user} has been suspended previously. You may consider taking further action based on their offence.`
           );
+          userSuspend.suspended.push({
+            date: new Date(Date.now()).toLocaleString(),
+            mod: message.author.username,
+            reason: reason
+          });
+          userSuspend.currentUsername = user.user.username;
+          userSuspend.currentNickname = user.nickname || '';
+          await userSuspend.save();
           return;
         }
         const newUser = new userSuspendModel({
           userId: user.id,
-          suspended: true
+          currentUsername: user.user.username,
+          currentNickname: user.nickname,
+          suspended: [
+            {
+              date: new Date(Date.now()).toLocaleString(),
+              mod: message.author.username,
+              reason: reason
+            }
+          ]
         });
         await newUser.save();
       }

--- a/src/commands/user.ts
+++ b/src/commands/user.ts
@@ -1,6 +1,5 @@
 import { CommandDef } from './command-def';
 import { UserSuspend, userSuspendModel } from '../APIs/mongo-suspend';
-import { MessageEmbed } from 'discord.js';
 
 export const userCommand: CommandDef = {
   prefix: 'user',
@@ -19,11 +18,22 @@ export const userCommand: CommandDef = {
     const userSuspend: UserSuspend | null = await userSuspendModel.findOne({
       userId: user.id
     });
-    const suspended = !!userSuspend?.suspended;
-    const userEmbed = new MessageEmbed()
-      .setTitle(user.nickname || user.user.username)
-      .setDescription('Here is the available data on them.')
-      .addFields({ name: 'Prior Suspension?', value: suspended });
-    message.channel.send(userEmbed);
+    if (!userSuspend) {
+      message.channel.send(`${user} has a clean record!`);
+      return;
+    }
+    message.channel.send(`Generating suspend record for ${user}...`);
+    message.channel.send(
+      `This user was last seen as ${userSuspend.currentUsername}`
+    );
+    if (userSuspend.currentNickname)
+      message.channel.send(
+        `This user last used the nickname ${userSuspend.currentNickname}`
+      );
+    const suspendLog = userSuspend.suspended.map(
+      (el) =>
+        `${el.mod} suspended them on ${el.date.split(',')[0]} for ${el.reason}`
+    );
+    message.channel.send(suspendLog.join('\n'));
   }
 };

--- a/src/commands/user.ts
+++ b/src/commands/user.ts
@@ -31,10 +31,11 @@ export const userCommand: CommandDef = {
     message.channel.send(
       `This user was last seen as ${userSuspend.currentUsername}`
     );
-    if (userSuspend.currentNickname)
+    if (userSuspend.currentNickname) {
       message.channel.send(
         `This user last used the nickname ${userSuspend.currentNickname}`
       );
+    }
     const suspendLog = userSuspend.suspended.map(
       (el) =>
         `${el.mod} suspended them on ${el.date.split(',')[0]} for ${el.reason}`

--- a/src/db/collections.ts
+++ b/src/db/collections.ts
@@ -1,0 +1,7 @@
+/**
+ * This is an enum of all the collections within the database.
+ */
+export enum Collections {
+  USER = 'users',
+  USER_SUSPENSIONS = 'user_suspensions'
+}

--- a/src/db/collections.ts
+++ b/src/db/collections.ts
@@ -3,5 +3,6 @@
  */
 export enum Collections {
   USER = 'users',
-  USER_SUSPENSIONS = 'user_suspensions'
+  USER_SUSPENSIONS = 'user_suspensions',
+  USER_LOGS = 'user_logs'
 }

--- a/src/db/models.ts
+++ b/src/db/models.ts
@@ -3,6 +3,7 @@ import { model } from 'mongoose';
 import { userSchema, User } from './user';
 import { UserSuspension } from './user-suspension';
 import { userSuspendSchema } from '../APIs/mongo-suspend';
+import { UserLog, userLogSchema } from './user-log';
 
 /**
  * Initializes, and holds all models by their collection
@@ -12,5 +13,6 @@ export const models = {
   [Collections.USER_SUSPENSIONS]: model<UserSuspension>(
     Collections.USER_SUSPENSIONS,
     userSuspendSchema
-  )
+  ),
+  [Collections.USER_LOGS]: model<UserLog>(Collections.USER_LOGS, userLogSchema)
 };

--- a/src/db/models.ts
+++ b/src/db/models.ts
@@ -1,0 +1,16 @@
+import { Collections } from './collections';
+import { model } from 'mongoose';
+import { userSchema, User } from './user';
+import { UserSuspension } from './user-suspension';
+import { userSuspendSchema } from '../APIs/mongo-suspend';
+
+/**
+ * Initializes, and holds all models by their collection
+ */
+export const models = {
+  [Collections.USER]: model<User>(Collections.USER, userSchema),
+  [Collections.USER_SUSPENSIONS]: model<UserSuspension>(
+    Collections.USER_SUSPENSIONS,
+    userSuspendSchema
+  )
+};

--- a/src/db/moderator.ts
+++ b/src/db/moderator.ts
@@ -18,10 +18,6 @@ export interface Moderator {
    * The discord server nickname of the mod
    */
   username: string;
-  /**
-   * The discord server nickname of the mod
-   */
-  nickname: string;
 }
 
 export const moderatorSchema = new Schema({
@@ -34,12 +30,6 @@ export const moderatorSchema = new Schema({
     // See snowflake documentation: https://discord.com/developers/docs/reference#snowflakes
   },
   username: {
-    type: Schema.Types.String,
-    required: true,
-    immutable: true
-    // TODO: Add entry limitations, check discord api
-  },
-  nickname: {
     type: Schema.Types.String,
     required: true,
     immutable: true

--- a/src/db/moderator.ts
+++ b/src/db/moderator.ts
@@ -11,9 +11,9 @@ import { Schema } from 'mongoose';
  */
 export interface Moderator {
   /**
-   * The discord server userId for the mod
+   * The discord user's _id
    */
-  userId: string | Snowflake;
+  _id: Snowflake;
   /**
    * The discord server nickname of the mod
    */
@@ -24,26 +24,25 @@ export interface Moderator {
   nickname: string;
 }
 
-export const moderatorSchema = new Schema(
-  {
-    userId: {
-      type: Schema.Types.String,
-      required: true,
-      immutable: true
-      // TODO: Add length validation check
-    },
-    username: {
-      type: Schema.Types.String,
-      required: true,
-      immutable: true
-      // TODO: Add entry limitations, check discord api
-    },
-    nickname: {
-      type: Schema.Types.String,
-      required: true,
-      immutable: true
-      // TODO: Add entry limitations, check discord api
-    }
+export const moderatorSchema = new Schema({
+  _id: {
+    type: Schema.Types.String,
+    required: true,
+    immutable: true,
+    unique: true
+    // TODO: Add length validation check, is it 17 or 18???
+    // See snowflake documentation: https://discord.com/developers/docs/reference#snowflakes
   },
-  { _id: false }
-);
+  username: {
+    type: Schema.Types.String,
+    required: true,
+    immutable: true
+    // TODO: Add entry limitations, check discord api
+  },
+  nickname: {
+    type: Schema.Types.String,
+    required: true,
+    immutable: true
+    // TODO: Add entry limitations, check discord api
+  }
+});

--- a/src/db/moderator.ts
+++ b/src/db/moderator.ts
@@ -1,0 +1,49 @@
+import { Snowflake } from 'discord.js';
+import { Schema } from 'mongoose';
+
+/**
+ * A moderator is similar to a user, except
+ * we **do not** keep track of previous usernames
+ * or nicknames.
+ *
+ * This isn't saved by itself, rather it is used to "log"
+ * actions taken by an admin.
+ */
+export interface Moderator {
+  /**
+   * The discord server userId for the mod
+   */
+  userId: string | Snowflake;
+  /**
+   * The discord server nickname of the mod
+   */
+  username: string;
+  /**
+   * The discord server nickname of the mod
+   */
+  nickname: string;
+}
+
+export const moderatorSchema = new Schema(
+  {
+    userId: {
+      type: Schema.Types.String,
+      required: true,
+      immutable: true
+      // TODO: Add length validation check
+    },
+    username: {
+      type: Schema.Types.String,
+      required: true,
+      immutable: true
+      // TODO: Add entry limitations, check discord api
+    },
+    nickname: {
+      type: Schema.Types.String,
+      required: true,
+      immutable: true
+      // TODO: Add entry limitations, check discord api
+    }
+  },
+  { _id: false }
+);

--- a/src/db/queries/create-new-user.ts
+++ b/src/db/queries/create-new-user.ts
@@ -1,0 +1,20 @@
+import { GuildMember } from 'discord.js';
+import { models } from '../models';
+import { User as DbUser } from '../user';
+
+/**
+ * Creates a new user from the guild member.
+ * Also saves the first guild-member
+ */
+export const createNewUser = (user: GuildMember): Promise<DbUser> =>
+  models.users.create({
+    _id: user.id,
+    identities: [
+      // create the first entry of identities
+      {
+        nickname: user.nickname || '',
+        username: user.user.username,
+        createdAt: new Date()
+      }
+    ]
+  });

--- a/src/db/queries/create-user-suspension.ts
+++ b/src/db/queries/create-user-suspension.ts
@@ -1,47 +1,7 @@
-import { User, GuildMember } from 'discord.js';
+import { GuildMember, User } from 'discord.js';
 import { models } from '../models';
 import { User as DbUser } from '../user';
-
-/**
- * Creates a user-suspension for the given user.
- */
-export const createUserSuspension = async ({
-  user,
-  moderator
-}: {
-  /**
-   * The user who to create a user-suspension for.
-   * This function will automatically create a user entry
-   * if there isn't one.
-   */
-  user: GuildMember;
-  /**
-   * The discord user that created this suspension,
-   * which is the moderator, or author of the command.
-   */
-  moderator: User;
-}): Promise<void> => {
-  const existingUser = await models.users.findOne({
-    _id: user.id
-  });
-
-  const dbUser = existingUser
-    ? await updateExistingIdentity({
-        existingUser,
-        user
-      })
-    : await models.users.create({
-        _id: user.id,
-        identities: [
-          // create the first entry of identities
-          {
-            nickname: user.nickname || '',
-            username: user.user.username,
-            createdAt: new Date()
-          }
-        ]
-      });
-};
+import { UserSuspension } from '../user-suspension';
 
 /**
  * Update the existing identity within the existing user.
@@ -68,4 +28,77 @@ const updateExistingIdentity = async ({
     createdAt: new Date()
   });
   return existingUser.save();
+};
+
+/**
+ * Creates a user-suspension for the given user.
+ */
+export const createUserSuspension = async ({
+  reason,
+  user,
+  moderator
+}: {
+  /**
+   * The reason the user is suspended.
+   */
+  reason: string;
+  /**
+   * The user who to create a user-suspension for.
+   * This function will automatically create a user entry
+   * if there isn't one.
+   */
+  user: GuildMember;
+  /**
+   * The discord user that created this suspension,
+   * which is the moderator, or author of the command.
+   */
+  moderator: User;
+}): Promise<{
+  /**
+   * The user updated/created
+   */
+  dbUser: DbUser;
+  /**
+   * The suspension created
+   */
+  userSuspension: UserSuspension;
+}> => {
+  const existingUser = await models.users.findOne({
+    _id: user.id
+  });
+
+  const manageUser = async (): Promise<DbUser> =>
+    existingUser
+      ? await updateExistingIdentity({
+          existingUser,
+          user
+        })
+      : await models.users.create({
+          _id: user.id,
+          identities: [
+            // create the first entry of identities
+            {
+              nickname: user.nickname || '',
+              username: user.user.username,
+              createdAt: new Date()
+            }
+          ]
+        });
+  const createSuspension = (): Promise<UserSuspension> =>
+    models.user_suspensions.create({
+      reason,
+      user: user.id,
+      moderator: {
+        _id: moderator.id,
+        username: moderator.username
+      },
+      createdAt: new Date()
+    });
+
+  const [dbUser, userSuspension] = await Promise.all([
+    manageUser(),
+    createSuspension()
+  ]);
+
+  return { dbUser, userSuspension };
 };

--- a/src/db/queries/create-user-suspension.ts
+++ b/src/db/queries/create-user-suspension.ts
@@ -1,0 +1,71 @@
+import { User, GuildMember } from 'discord.js';
+import { models } from '../models';
+import { User as DbUser } from '../user';
+
+/**
+ * Creates a user-suspension for the given user.
+ */
+export const createUserSuspension = async ({
+  user,
+  moderator
+}: {
+  /**
+   * The user who to create a user-suspension for.
+   * This function will automatically create a user entry
+   * if there isn't one.
+   */
+  user: GuildMember;
+  /**
+   * The discord user that created this suspension,
+   * which is the moderator, or author of the command.
+   */
+  moderator: User;
+}): Promise<void> => {
+  const existingUser = await models.users.findOne({
+    _id: user.id
+  });
+
+  const dbUser = existingUser
+    ? await updateExistingIdentity({
+        existingUser,
+        user
+      })
+    : await models.users.create({
+        _id: user.id,
+        identities: [
+          // create the first entry of identities
+          {
+            nickname: user.nickname || '',
+            username: user.user.username,
+            createdAt: new Date()
+          }
+        ]
+      });
+};
+
+/**
+ * Update the existing identity within the existing user.
+ */
+const updateExistingIdentity = async ({
+  existingUser,
+  user
+}: {
+  existingUser: DbUser;
+  user: GuildMember;
+}): Promise<DbUser> => {
+  const existingIdentity = (existingUser?.identities || []).find(
+    ({ nickname, username }) =>
+      user.nickname === nickname && user.user.username === username
+  );
+  if (existingIdentity) {
+    // if the identity already exists, just return
+    return existingUser;
+  }
+  // otherwise, add a new identity
+  existingUser.identities.push({
+    nickname: user.nickname || '',
+    username: user.user.username,
+    createdAt: new Date()
+  });
+  return existingUser.save();
+};

--- a/src/db/queries/get-user-entries.ts
+++ b/src/db/queries/get-user-entries.ts
@@ -1,0 +1,70 @@
+import { GuildMember } from 'discord.js';
+import { models } from '../models';
+import { User as DbUser } from '../user';
+import { UserLog } from '../user-log';
+import { UserSuspension } from '../user-suspension';
+
+export type UserLogEntry = UserLog | UserSuspension;
+
+export enum GetUserEntriesFilter {
+  LOGS = 'logs',
+  SUSPENSIONS = 'suspensions',
+  ALL = 'all'
+}
+
+/**
+ * Returns the list of user-entries for the given user, if
+ * there are any.
+ */
+export const getUserEntries = async ({
+  user,
+  filter
+}: {
+  /**
+   * The user to load logs for
+   */
+  user: GuildMember;
+  /**
+   * What to search for
+   *
+   * **note** might want to rename this property
+   */
+  filter: GetUserEntriesFilter;
+}): Promise<{
+  dbUser: DbUser | undefined;
+  entries: Array<UserLogEntry>;
+}> => {
+  const existingUser = await models.users.findOne({
+    _id: user.id
+  });
+  if (!existingUser) {
+    // if no user exists, just return empty
+    return {
+      dbUser: undefined,
+      entries: []
+    };
+  }
+  const [logs, suspensions] = await Promise.all([
+    filter.includes(GetUserEntriesFilter.ALL) ||
+    filter.includes(GetUserEntriesFilter.LOGS)
+      ? models.user_logs.find({
+          user: user.id
+        })
+      : Promise.resolve([]),
+    filter.includes(GetUserEntriesFilter.ALL) ||
+    filter.includes(GetUserEntriesFilter.SUSPENSIONS)
+      ? models.user_suspensions.find({
+          user: user.id
+        })
+      : Promise.resolve([])
+  ]);
+
+  return {
+    dbUser: existingUser,
+    // sort the entries
+    entries: [...logs, ...suspensions].sort(
+      ({ createdAt: createdAtA }, { createdAt: createdAtB }) =>
+        createdAtA.getTime() - createdAtB.getTime()
+    )
+  };
+};

--- a/src/db/queries/update-existing-identity.ts
+++ b/src/db/queries/update-existing-identity.ts
@@ -1,0 +1,28 @@
+import { User } from '../user';
+import { GuildMember } from 'discord.js';
+/**
+ * Update the existing identity within the existing user.
+ */
+export const updateExistingIdentity = async ({
+  existingUser,
+  user
+}: {
+  existingUser: User;
+  user: GuildMember;
+}): Promise<User> => {
+  const existingIdentity = (existingUser?.identities || []).find(
+    ({ nickname, username }) =>
+      user.nickname === nickname && user.user.username === username
+  );
+  if (existingIdentity) {
+    // if the identity already exists, just return
+    return existingUser;
+  }
+  // otherwise, add a new identity
+  existingUser.identities.push({
+    nickname: user.nickname || '',
+    username: user.user.username,
+    createdAt: new Date()
+  });
+  return existingUser.save();
+};

--- a/src/db/user-identity.ts
+++ b/src/db/user-identity.ts
@@ -1,0 +1,45 @@
+import { Schema } from 'mongoose';
+
+/**
+ * A user-identity is an entry saved
+ * for any changes related to a discord user-name for a
+ * given discord user. This is used to keep track
+ * of user information in-case they change their name/username
+ */
+export interface UserIdentity {
+  /**
+   * The discord username.
+   */
+  username: string;
+  /**
+   * The discord server nickname.
+   */
+  nickname: string;
+  /**
+   * The date and time this entry was saved
+   */
+  createdAt: Date;
+}
+
+export const userIdentitySchema = new Schema(
+  {
+    username: {
+      type: Schema.Types.String,
+      required: true,
+      immutable: true
+      // TODO: Add entry limitations, check discord api
+    },
+    nickname: {
+      type: Schema.Types.String,
+      required: true,
+      immutable: true
+      // TODO: Add entry limitations, check discord api
+    }
+  },
+  {
+    _id: false,
+    timestamps: {
+      createdAt: 'createdAt'
+    }
+  }
+);

--- a/src/db/user-log.ts
+++ b/src/db/user-log.ts
@@ -1,14 +1,14 @@
-import { Moderator, moderatorSchema } from './moderator';
-import { Schema, Document } from 'mongoose';
-import { User } from 'discord.js';
+import { Document, Schema } from 'mongoose';
+import { User } from './user';
 import { ObjectId } from 'mongodb';
+import { Moderator, moderatorSchema } from './moderator';
 import { Collections } from './collections';
 
 /**
- * A user-suspension is used to keep track of suspensions
- * made on a user by admins.
+ * A user-log is used to keep track of things saved
+ * by admins via the `userlog` command
  */
-export interface UserSuspension extends Document {
+export interface UserLog extends Document {
   /**
    * The parent user
    *
@@ -30,7 +30,7 @@ export interface UserSuspension extends Document {
   createdAt: Date;
 }
 
-export const userSuspensionSchema = new Schema(
+export const userLogSchema = new Schema(
   {
     user: {
       type: Schema.Types.ObjectId,
@@ -38,10 +38,10 @@ export const userSuspensionSchema = new Schema(
       immutable: true,
       ref: Collections.USER
     },
-    reason: {
-      type: Schema.Types.String
-      // TODO: add default
-      // TODO: add length
+    message: {
+      type: Schema.Types.String,
+      required: true,
+      immutable: true
     },
     moderator: moderatorSchema
   },

--- a/src/db/user-log.ts
+++ b/src/db/user-log.ts
@@ -18,9 +18,9 @@ export interface UserLog extends Document {
    */
   user: Snowflake;
   /**
-   * The reason the user was suspended.
+   * The message we are to save against the user
    */
-  reason: string;
+  message: string;
   /**
    * The moderator who performed this action
    */

--- a/src/db/user-log.ts
+++ b/src/db/user-log.ts
@@ -1,8 +1,7 @@
+import { Snowflake } from 'discord.js';
 import { Document, Schema } from 'mongoose';
-import { User } from './user';
-import { ObjectId } from 'mongodb';
-import { Moderator, moderatorSchema } from './moderator';
 import { Collections } from './collections';
+import { Moderator, moderatorSchema } from './moderator';
 
 /**
  * A user-log is used to keep track of things saved
@@ -14,8 +13,10 @@ export interface UserLog extends Document {
    *
    * **NOTE** I'm unsure if we should keep this as the objectId reference
    * or use the discord provided snowflake
+   *
+   * The discord user's _id
    */
-  user: string | ObjectId | User;
+  user: Snowflake;
   /**
    * The reason the user was suspended.
    */
@@ -33,7 +34,7 @@ export interface UserLog extends Document {
 export const userLogSchema = new Schema(
   {
     user: {
-      type: Schema.Types.ObjectId,
+      type: Schema.Types.String,
       required: true,
       immutable: true,
       ref: Collections.USER

--- a/src/db/user-suspension.ts
+++ b/src/db/user-suspension.ts
@@ -1,0 +1,53 @@
+import { Moderator, moderatorSchema } from './moderator';
+import { Schema, Document } from 'mongoose';
+import { User } from 'discord.js';
+import { ObjectId } from 'mongodb';
+import { Collections } from './collections';
+
+/**
+ * A user-suspension is used to keep track of suspensions
+ * made on a user by admins.
+ */
+export interface UserSuspension extends Document {
+  /**
+   * The parent user
+   *
+   * **NOTE** I'm unsure if we should keep this as the objectId reference
+   * or use the discord provided snowflake
+   */
+  user: string | ObjectId | User;
+  /**
+   * The reason the user was suspended.
+   */
+  reason: string;
+  /**
+   * The moderator who performed this action
+   */
+  moderator: Moderator;
+  /**
+   * The date and time this entry was saved
+   */
+  createdAt: Date;
+}
+
+export const userSuspensionSchema = new Schema(
+  {
+    user: {
+      type: Schema.Types.ObjectId,
+      required: true,
+      immutable: true,
+      ref: Collections.USER_SUSPENSIONS
+    },
+    reason: {
+      type: Schema.Types.String
+      // TODO: add default
+      // TODO: add length
+    },
+    moderator: moderatorSchema
+  },
+  {
+    timestamps: {
+      createdAt: 'createdAt'
+    }
+  }
+);

--- a/src/db/user-suspension.ts
+++ b/src/db/user-suspension.ts
@@ -1,6 +1,6 @@
 import { Moderator, moderatorSchema } from './moderator';
 import { Schema, Document } from 'mongoose';
-import { User } from 'discord.js';
+import { User, Snowflake } from 'discord.js';
 import { ObjectId } from 'mongodb';
 import { Collections } from './collections';
 
@@ -15,7 +15,7 @@ export interface UserSuspension extends Document {
    * **NOTE** I'm unsure if we should keep this as the objectId reference
    * or use the discord provided snowflake
    */
-  user: string | ObjectId | User;
+  user: Snowflake;
   /**
    * The reason the user was suspended.
    */
@@ -33,7 +33,7 @@ export interface UserSuspension extends Document {
 export const userSuspensionSchema = new Schema(
   {
     user: {
-      type: Schema.Types.ObjectId,
+      type: Schema.Types.String,
       required: true,
       immutable: true,
       ref: Collections.USER

--- a/src/db/user-suspension.ts
+++ b/src/db/user-suspension.ts
@@ -1,8 +1,7 @@
-import { Moderator, moderatorSchema } from './moderator';
-import { Schema, Document } from 'mongoose';
-import { User, Snowflake } from 'discord.js';
-import { ObjectId } from 'mongodb';
+import { Snowflake } from 'discord.js';
+import { Document, Schema } from 'mongoose';
 import { Collections } from './collections';
+import { Moderator, moderatorSchema } from './moderator';
 
 /**
  * A user-suspension is used to keep track of suspensions

--- a/src/db/user.ts
+++ b/src/db/user.ts
@@ -1,6 +1,6 @@
-import { ObjectId } from 'mongodb';
+import { Snowflake } from 'discord.js';
+import { Document, Schema } from 'mongoose';
 import { UserIdentity, userIdentitySchema } from './user-identity';
-import { Schema, Document } from 'mongoose';
 /**
  * This is an entry for a user, this is normalized
  * for "future" proofing future features that will
@@ -8,9 +8,9 @@ import { Schema, Document } from 'mongoose';
  */
 export interface User extends Document {
   /**
-   * The discord server userId
+   * The discord user's _id
    */
-  userId: string | ObjectId;
+  _id: Snowflake;
   /**
    * List of previous "identity" information
    * for a given user. Used to keep track of
@@ -21,13 +21,13 @@ export interface User extends Document {
 
 export const userSchema = new Schema(
   {
-    userId: {
+    _id: {
       type: Schema.Types.String,
       required: true,
       unique: true,
-      // this isn't "seen" by types and available after 5.6
       immutable: true
-      // TODO: Add length validation check
+      // TODO: Add length validation check, is it 17 or 18???
+      // See snowflake documentation: https://discord.com/developers/docs/reference#snowflakes
     },
     identities: [userIdentitySchema]
   },

--- a/src/db/user.ts
+++ b/src/db/user.ts
@@ -1,0 +1,39 @@
+import { ObjectId } from 'mongodb';
+import { UserIdentity, userIdentitySchema } from './user-identity';
+import { Schema, Document } from 'mongoose';
+/**
+ * This is an entry for a user, this is normalized
+ * for "future" proofing future features that will
+ * deal with the discord-user.
+ */
+export interface User extends Document {
+  /**
+   * The discord server userId
+   */
+  userId: string | ObjectId;
+  /**
+   * List of previous "identity" information
+   * for a given user. Used to keep track of
+   * users incase they change their discord user name.
+   */
+  identities: Array<UserIdentity>;
+}
+
+export const userSchema = new Schema(
+  {
+    userId: {
+      type: Schema.Types.String,
+      required: true,
+      unique: true,
+      // this isn't "seen" by types and available after 5.6
+      immutable: true
+      // TODO: Add length validation check
+    },
+    identities: [userIdentitySchema]
+  },
+  {
+    timestamps: {
+      createdAt: 'createdAt'
+    }
+  }
+);


### PR DESCRIPTION
**Description:**
- Refactor schema/model setup with mongoose to reflect the new "userlog" feature, while making some changes to support pre-existing suspend logic

Related to #152 

**note** this is a draft since I want to get some feedback on how the schema is currently setup. I'm also not sure about how the `userId` isn't the same as the mongodb `_id` property, which could just be made to be the discord `snowflake` identifier instead. (its a rather long unique number)

