### PR TITLE
Asignee fix

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bradtaniguchi @nhcarrigan

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: '[Bug]'
 labels: bug
-assignees: 'bradtaniguchi, nhcarrigan'
+assignees:
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,6 @@ name: Bug report
 about: Create a report to help us improve
 title: '[Bug]'
 labels: bug
-assignees:
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/chore_request.md
+++ b/.github/ISSUE_TEMPLATE/chore_request.md
@@ -3,7 +3,7 @@ name: Chore
 about: Reminder to perform minor changes, or "chore"
 title: '[CHORE]'
 labels: chore
-assignees: 'bradtaniguchi, nhcarrigan'
+assignees:
 ---
 
 **What needs to be done**

--- a/.github/ISSUE_TEMPLATE/chore_request.md
+++ b/.github/ISSUE_TEMPLATE/chore_request.md
@@ -3,7 +3,6 @@ name: Chore
 about: Reminder to perform minor changes, or "chore"
 title: '[CHORE]'
 labels: chore
-assignees:
 ---
 
 **What needs to be done**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: '[FEATURE]'
 labels: feature
-assignees: 'bradtaniguchi, nhcarrigan'
+assignees:
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,6 @@ name: Feature request
 about: Suggest an idea for this project
 title: '[FEATURE]'
 labels: feature
-assignees:
 ---
 
 **Is your feature request related to a problem? Please describe.**


### PR DESCRIPTION
**Description:**
I deleted the automatic assignees so that @bradtaniguchi and @nhcarrigan don't automatically get assigned to every issue. I also created a CODEOWNERS file with @bradtaniguchi and @nhcarrigan as owners so they can assign and unassign people from issues.
<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->
This fixes the Remove automatic assignees to issue templates, keep them in PR issue posted by @bradtaniguchi.
Closes #XXXXX
