### PR TITLE
Add message.send to error handling

### DIFF
--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -17,11 +17,17 @@ export const closeCommand: CommandDef = {
         logger.warn(
           `${message.author.username} did not have the correct permissions.`
         );
+        message.channel.send(
+          'Sorry, this command is restricted to moderators.'
+        );
         return;
       }
       const flag = message.content.split(' ')[2];
       if (flag !== 'accepted' && flag !== 'denied') {
         logger.warn('invalid paramater');
+        message.channel.send(
+          "I don't see the right flags. Please use `close [accepted/denied] [@user]`."
+        );
         return;
       }
       const target = message.channel as TextChannel;
@@ -30,12 +36,9 @@ export const closeCommand: CommandDef = {
         (channel) => channel.name === config.LOG_MSG_CHANNEL
       ) as TextChannel;
       //check for user permissions
-      if (!message.member?.hasPermission('MANAGE_CHANNELS')) {
-        logger.warn('Missing permissions.');
-        return;
-      }
       if (!log) {
         logger.warn('Log channel not found.');
+        message.channel.send('Sorry, but I could not find the log channel.');
         return;
       }
 
@@ -44,6 +47,9 @@ export const closeCommand: CommandDef = {
         !target.parent?.name.includes(config.SUSPEND_CATEGORY)
       ) {
         logger.warn('Cannot delete non-temporary channel');
+        message.channel.send(
+          'This command only works on the suspended-user channels.'
+        );
         return;
       }
 
@@ -54,6 +60,7 @@ export const closeCommand: CommandDef = {
         );
         if (!suspend) {
           logger.warn('Cannot find suspend role');
+          message.channel.send('Sorry, I could not find your suspended role.');
         } else {
           await message.mentions.members.first()?.roles.remove([suspend]);
           status = `The appeal was approved and ${message.mentions.members.first()}'s access was restored.`;

--- a/src/commands/format.ts
+++ b/src/commands/format.ts
@@ -11,19 +11,20 @@ export const format: CommandDef = {
     try {
       if (message.content.split(' ').length < 3) {
         logger.warn('Missing message ID');
+        message.channel.send('Sorry, please include a valid message URl.');
         return;
       }
       const messageURL = message.content.split(' ')[2];
       const messageID = messageURL.split('/')[messageURL.split('/').length - 1];
       if (!messageID || isNaN(parseInt(messageID))) {
         logger.warn('invalid syntax');
-        message.channel.send('Invalid syntax');
+        message.channel.send('Sorry, please include a valid message URL.');
         return;
       }
       const messageContent = await message.channel.messages.fetch(messageID);
       if (!messageContent) {
         logger.warn('Message not found');
-        message.channel.send('Message not found');
+        message.channel.send('Sorry, but I could not find that message.');
         return;
       }
       return addFormatting(messageContent);

--- a/src/commands/suspend.ts
+++ b/src/commands/suspend.ts
@@ -15,6 +15,9 @@ export const suspendCommand: CommandDef = {
         logger.warn(
           `${message.author.username} did not have the correct permissions.`
         );
+        message.channel.send(
+          'Sorry, this command is restricted to moderators.'
+        );
         return;
       }
 
@@ -25,6 +28,7 @@ export const suspendCommand: CommandDef = {
 
       if (!modChannel) {
         logger.warn('Log channel not found.');
+        message.channel.send('Sorry, I could not find your log channel.');
         return;
       }
 
@@ -36,6 +40,7 @@ export const suspendCommand: CommandDef = {
 
       if (!category) {
         logger.warn('Missing suspend category.');
+        message.channel.send('Sorry, I could not find your suspend category.');
         return;
       }
 
@@ -45,6 +50,7 @@ export const suspendCommand: CommandDef = {
       );
       if (!suspend) {
         logger.warn(`Missing suspend role.`);
+        message.channel.send('Sorry, I could not find your suspend role.');
         return;
       }
 
@@ -55,6 +61,7 @@ export const suspendCommand: CommandDef = {
 
       if (!botRole) {
         logger.warn('Bot role not found.');
+        message.channel.send('Sorry, I could not find my bot role.');
         return;
       }
 
@@ -66,6 +73,7 @@ export const suspendCommand: CommandDef = {
 
       if (!modRole) {
         logger.warn('Mod role not found.');
+        message.channel.send('Sorry, I could not find your moderator role.');
         return;
       }
 
@@ -76,6 +84,9 @@ export const suspendCommand: CommandDef = {
       //check for valid user tag
       if (!user) {
         message.channel.send(`Invalid user tag.`);
+        message.channel.send(
+          'Sorry, but you did not provide a valid user tag.'
+        );
         return;
       }
 

--- a/src/commands/user.ts
+++ b/src/commands/user.ts
@@ -11,16 +11,23 @@ export const userCommand: CommandDef = {
 
     if (!user) {
       logger.warn('No user provided.');
+      message.channel.send('Sorry, please provide a valid user mention.');
       return;
     }
 
     if (!message.member?.hasPermission('KICK_MEMBERS')) {
       logger.warn('Invalid permissions');
+      message.channel.send(
+        'Sorry, but this command is restricted to moderators.'
+      );
       return;
     }
 
     if (!config.MONGO_URI) {
       logger.warn('No database configured');
+      message.channel.send(
+        'Sorry, but this command requires an active database connection.'
+      );
       return;
     }
 


### PR DESCRIPTION
**Description:**

I went through and hit all of our `if (x) logger.warn` steps to ensure the bot stills sends a response to the channel. This will prevent "silent errors", where the end user assumes the bot is broken because it does not reply.

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #164 
