### PR TITLE
Modify permission check

### DIFF
--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -13,7 +13,7 @@ export const closeCommand: CommandDef = {
   usage: 'close [accepted | denied] [user]',
   command: async (message, { config }): Promise<void> => {
     try {
-      if (!message.member?.hasPermission('MANAGE_CHANNELS')) {
+      if (!message.member?.hasPermission('KICK_MEMBERS')) {
         logger.warn(
           `${message.author.username} did not have the correct permissions.`
         );


### PR DESCRIPTION
**Description:**

Modifies the permissions check on the `close` command to ensure any moderator who calls the `suspend` can also use `close`.

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
