### PR TITLE
Add reaction-based role assignment

### DIFF
--- a/src/config/get-config.ts
+++ b/src/config/get-config.ts
@@ -81,6 +81,15 @@ export interface Config {
    * is set to `false`, then the feature will be available in all channels
    */
   AUTO_LINK_CHANNEL: string | false;
+  /**
+   * The role to assign to users who wish to be notified of new live streams.
+   */
+  STREAM_NOTIF_ROLE: string;
+  /**
+   * The message ID for the livestream role assignment - users react to this
+   * message to be assigned the role.
+   */
+  STREAM_MSG_ID: string;
 }
 /**
  * @name getConfig
@@ -103,6 +112,8 @@ export function getConfig(): Config {
     ONLINE_AT: getBotOnlineAt() || '',
     MOD_ROLE: process.env.MOD_ROLE || '',
     AUTO_LINK_LIMIT: Number(process.env.AUTO_LINK_LIMIT) || 5,
-    AUTO_LINK_CHANNEL: process.env.AUTO_LINK_CHANNEL || false
+    AUTO_LINK_CHANNEL: process.env.AUTO_LINK_CHANNEL || false,
+    STREAM_NOTIF_ROLE: process.env.STREAM_NOTIF_ROLE || '',
+    STREAM_MSG_ID: process.env.STREAM_MSG_ID || ''
   };
 }

--- a/src/config/get-config.ts
+++ b/src/config/get-config.ts
@@ -84,10 +84,11 @@ export interface Config {
   /**
    * The role to assign to users who wish to be notified of new live streams.
    */
-  STREAM_NOTIF_ROLE: string;
+  STREAM_NOTIFY_ROLE: string;
   /**
    * The message ID for the livestream role assignment - users react to this
-   * message to be assigned the role.
+   * message to be assigned the role. This ID is obtained by right clicking
+   * on the message you want to use for reactions and selecting "Copy ID".
    */
   STREAM_MSG_ID: string;
 }
@@ -113,7 +114,7 @@ export function getConfig(): Config {
     MOD_ROLE: process.env.MOD_ROLE || '',
     AUTO_LINK_LIMIT: Number(process.env.AUTO_LINK_LIMIT) || 5,
     AUTO_LINK_CHANNEL: process.env.AUTO_LINK_CHANNEL || false,
-    STREAM_NOTIF_ROLE: process.env.STREAM_NOTIF_ROLE || '',
+    STREAM_NOTIFY_ROLE: process.env.STREAM_NOTIFY_ROLE || '',
     STREAM_MSG_ID: process.env.STREAM_MSG_ID || ''
   };
 }

--- a/src/reactions/bootstrap-reactions.ts
+++ b/src/reactions/bootstrap-reactions.ts
@@ -16,7 +16,7 @@ export const bootstrapReactions = ({
     new Collection<string, ReactionDef>()
   );
 
-  client.on('messageReactionAdd', async (reaction) => {
+  client.on('messageReactionAdd', async (reaction, user) => {
     if (reaction.partial) {
       try {
         await reaction.fetch();
@@ -34,7 +34,9 @@ export const bootstrapReactions = ({
       return;
     }
     try {
-      reactions.get(reaction.emoji.name)?.command(reaction, { client, config });
+      reactions
+        .get(reaction.emoji.name)
+        ?.command(reaction, { client, config, user });
     } catch (error) {
       // don't warn end users, just log the error
       logger.error(error);

--- a/src/reactions/livestream-reaction.ts
+++ b/src/reactions/livestream-reaction.ts
@@ -6,7 +6,7 @@ export const liveStreamReaction: ReactionDef = {
   description: 'Adds the livestream role to the user who reacts',
   command: async (reaction, { config, user }) => {
     const streamRole = reaction.message.guild?.roles.cache.find(
-      (role) => role.name === config.STREAM_NOTIF_ROLE
+      (role) => role.name === config.STREAM_NOTIFY_ROLE
     );
     if (!streamRole) {
       logger.warn('Stream role not found');

--- a/src/reactions/livestream-reaction.ts
+++ b/src/reactions/livestream-reaction.ts
@@ -1,0 +1,34 @@
+import { logger } from '../utilities/logger';
+import { ReactionDef } from './reaction-def';
+
+export const liveStreamReaction: ReactionDef = {
+  emoji: '🎥',
+  description: 'Adds the livestream role to the user who reacts',
+  command: async (reaction, { config, user }) => {
+    const streamRole = reaction.message.guild?.roles.cache.find(
+      (role) => role.name === config.STREAM_NOTIF_ROLE
+    );
+    if (!streamRole) {
+      logger.warn('Stream role not found');
+      return;
+    }
+    if (reaction.message.id !== config.STREAM_MSG_ID) {
+      return;
+    }
+    if (user.partial) {
+      user = await user.fetch();
+    }
+    const target = reaction.message.guild?.member(user);
+    if (!target) {
+      logger.warn('user error');
+      return;
+    }
+    if (target.roles.cache.find((r) => r === streamRole)) {
+      target.roles.remove(streamRole).catch((e) => logger.error(e));
+      reaction.message.reactions.cache.get('🎥')?.remove();
+      return;
+    }
+    target.roles.add(streamRole).catch((e) => logger.error(e));
+    reaction.message.reactions.cache.get('🎥')?.remove();
+  }
+};

--- a/src/reactions/reaction-def.ts
+++ b/src/reactions/reaction-def.ts
@@ -1,4 +1,4 @@
-import { MessageReaction, Client } from 'discord.js';
+import { MessageReaction, Client, User, PartialUser } from 'discord.js';
 import { Config } from '../config/get-config';
 
 /**
@@ -7,6 +7,7 @@ import { Config } from '../config/get-config';
 export interface ReactionDefArgs {
   client: Client;
   config: Config;
+  user: User | PartialUser;
 }
 /**
  * A reaction def defines how to handle specific

--- a/src/reactions/reactions.ts
+++ b/src/reactions/reactions.ts
@@ -1,8 +1,13 @@
 import { ReactionDef } from './reaction-def';
 import { pin } from './pin';
 import { formatReaction } from './format-reaction';
+import { liveStreamReaction } from './livestream-reaction';
 
 /**
  * List of commands to react based on message reactions
  */
-export const REACTIONS: Array<ReactionDef> = [pin, formatReaction];
+export const REACTIONS: Array<ReactionDef> = [
+  pin,
+  formatReaction,
+  liveStreamReaction
+];


### PR DESCRIPTION
**Description:**

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

After Bjorno ran it by Quincy, the decision was made to add a role `Live Streams` to the channel. This role exists for users who wish to receive notifications when there is a live stream available on fCC (the YouTube, I think?). 

This PR adds a reaction feature to the bot that will allow us to post a message in `#rules`. Users can react with the 🎥 emoji and the bot will assign them the role and remove the reaction. Users who *have* the role can react again with 🎥 to have the role removed. 

The bot will need two new environment variables when this ships:
`STREAM_NOTIFY_ROLE` is the name of the role the bot should add/remove
`STREAM_MSG_ID` is the `id` of the message the users should react to (to prevent the event from firing on 🎥 reactions elsewhere). 

Closes #XXXXX
