### PR TITLE
Make thank feature togglable

### DIFF
--- a/src/commands/bootstrap-commands.ts
+++ b/src/commands/bootstrap-commands.ts
@@ -159,6 +159,6 @@ export const bootstrapCommands = ({
         }
       }
     }
-    thanks(message);
+    thanks(message, config);
   });
 };

--- a/src/commands/thanks.ts
+++ b/src/commands/thanks.ts
@@ -1,4 +1,5 @@
 import { Message } from 'discord.js';
+import { Config } from '../config/get-config';
 
 /**
  * Thanks handler that will show a nice message
@@ -7,7 +8,13 @@ import { Message } from 'discord.js';
  * TODO: maybe rename to be more clear what this does?
  * @param message the message we are to check against.
  */
-export async function thanks(message: Message): Promise<Message | void> {
+export async function thanks(
+  message: Message,
+  config: Config
+): Promise<Message | void> {
+  if (!config.THANK_OPTION) {
+    return;
+  }
   if (!shouldThank(message)) {
     return;
   }

--- a/src/config/get-config.ts
+++ b/src/config/get-config.ts
@@ -91,6 +91,10 @@ export interface Config {
    * on the message you want to use for reactions and selecting "Copy ID".
    */
   STREAM_MSG_ID: string;
+  /**
+   * Option to enable/disable the thanks feature.
+   */
+  THANK_OPTION: boolean;
 }
 /**
  * @name getConfig
@@ -115,6 +119,7 @@ export function getConfig(): Config {
     AUTO_LINK_LIMIT: Number(process.env.AUTO_LINK_LIMIT) || 5,
     AUTO_LINK_CHANNEL: process.env.AUTO_LINK_CHANNEL || false,
     STREAM_NOTIFY_ROLE: process.env.STREAM_NOTIFY_ROLE || '',
-    STREAM_MSG_ID: process.env.STREAM_MSG_ID || ''
+    STREAM_MSG_ID: process.env.STREAM_MSG_ID || '',
+    THANK_OPTION: !!process.env.THANK_OPTION || false
   };
 }


### PR DESCRIPTION
**Description:**

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Because the bot has access to the suspended channels, the brownie points feature triggers. This PR adds a config env to require the thanks feature be turned on before it will run. 

Closes #XXXXX
