### PR TITLE
Add Halloween feature

### DIFF
--- a/src/config/get-config.ts
+++ b/src/config/get-config.ts
@@ -96,11 +96,13 @@ export interface Config {
    */
   THANK_OPTION: boolean;
   /**
-   * Announcement message ID for Halloween event
+   * Announcement message ID for Halloween event. This should be the ID
+   * of the message users can react to and receive HALLOWEEN_ROLE.
    */
   HALLOWEEN_ANNOUNCEMENT: string;
   /**
-   * Role for Halloween event.
+   * Role for Halloween event. The role grants access to the halloween event channel,
+   * which is the channel the Trick'cord Treat bot will be operating in.
    */
   HALLOWEEN_ROLE: string;
 }

--- a/src/config/get-config.ts
+++ b/src/config/get-config.ts
@@ -95,6 +95,14 @@ export interface Config {
    * Option to enable/disable the thanks feature.
    */
   THANK_OPTION: boolean;
+  /**
+   * Announcement message ID for Halloween event
+   */
+  HALLOWEEN_ANNOUNCEMENT: string;
+  /**
+   * Role for Halloween event.
+   */
+  HALLOWEEN_ROLE: string;
 }
 /**
  * @name getConfig
@@ -120,6 +128,8 @@ export function getConfig(): Config {
     AUTO_LINK_CHANNEL: process.env.AUTO_LINK_CHANNEL || false,
     STREAM_NOTIFY_ROLE: process.env.STREAM_NOTIFY_ROLE || '',
     STREAM_MSG_ID: process.env.STREAM_MSG_ID || '',
-    THANK_OPTION: !!process.env.THANK_OPTION || false
+    THANK_OPTION: !!process.env.THANK_OPTION || false,
+    HALLOWEEN_ANNOUNCEMENT: process.env.HALLOWEEN_ANNOUNCEMENT || '',
+    HALLOWEEN_ROLE: process.env.HALLOWEEN_ROLE || ''
   };
 }

--- a/src/reactions/halloween.ts
+++ b/src/reactions/halloween.ts
@@ -3,8 +3,13 @@ import { ReactionDef } from './reaction-def';
 
 export const halloweenReaction: ReactionDef = {
   emoji: '🎃',
-  description: 'Adds the halloween role to the user who reacts',
+  description:
+    'Adds the halloween role to the user who reacts. The halloween role includes no additional permissions, but unlocks access to the halloween event channel. This allows the user to opt-in to participating in the Discord-powered trick or treat event.',
   command: async (reaction, { config, user }) => {
+    if (!config.HALLOWEEN_ROLE || !config.HALLOWEEN_ANNOUNCEMENT) {
+      logger.warn('Missing config values for Halloween feature.');
+      return;
+    }
     const hallowRole = reaction.message.guild?.roles.cache.find(
       (role) => role.name === config.HALLOWEEN_ROLE
     );
@@ -20,7 +25,9 @@ export const halloweenReaction: ReactionDef = {
     }
     const target = reaction.message.guild?.member(user);
     if (!target) {
-      logger.warn('user error');
+      logger.warn(
+        'A user reacted to the Halloween message, but the bot was unable to locate them.'
+      );
       return;
     }
     if (target.roles.cache.find((r) => r === hallowRole)) {

--- a/src/reactions/halloween.ts
+++ b/src/reactions/halloween.ts
@@ -1,0 +1,34 @@
+import { logger } from '../utilities/logger';
+import { ReactionDef } from './reaction-def';
+
+export const halloweenReaction: ReactionDef = {
+  emoji: '🎃',
+  description: 'Adds the halloween role to the user who reacts',
+  command: async (reaction, { config, user }) => {
+    const hallowRole = reaction.message.guild?.roles.cache.find(
+      (role) => role.name === config.HALLOWEEN_ROLE
+    );
+    if (!hallowRole) {
+      logger.warn('Halloween role not found');
+      return;
+    }
+    if (reaction.message.id !== config.HALLOWEEN_ANNOUNCEMENT) {
+      return;
+    }
+    if (user.partial) {
+      user = await user.fetch();
+    }
+    const target = reaction.message.guild?.member(user);
+    if (!target) {
+      logger.warn('user error');
+      return;
+    }
+    if (target.roles.cache.find((r) => r === hallowRole)) {
+      target.roles.remove(hallowRole).catch((e) => logger.error(e));
+      reaction.message.reactions.cache.get('🎃')?.remove();
+      return;
+    }
+    target.roles.add(hallowRole).catch((e) => logger.error(e));
+    reaction.message.reactions.cache.get('🎃')?.remove();
+  }
+};

--- a/src/reactions/reactions.ts
+++ b/src/reactions/reactions.ts
@@ -2,6 +2,7 @@ import { ReactionDef } from './reaction-def';
 import { pin } from './pin';
 import { formatReaction } from './format-reaction';
 import { liveStreamReaction } from './livestream-reaction';
+import { halloweenReaction } from './halloween';
 
 /**
  * List of commands to react based on message reactions
@@ -9,5 +10,6 @@ import { liveStreamReaction } from './livestream-reaction';
 export const REACTIONS: Array<ReactionDef> = [
   pin,
   formatReaction,
-  liveStreamReaction
+  liveStreamReaction,
+  halloweenReaction
 ];


### PR DESCRIPTION
**Description:**

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

This PR adds a Halloween reaction feature, similar to the live stream feature. We will require two new `.env` values: `HALLOWEEN_ANNOUNCEMENT` and `HALLOWEEN_ROLE`. 

The PR itself should be fine to merge (as the env values are essential for the functionality), but the env values should not be added until we receive approval for the event.

Closes #XXXXX
