### PR TITLE
Disable halloween feature

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,5 +30,6 @@ module.exports = {
     'no-console': 'error',
     eqeqeq: ['error', 'always'],
     curly: ['error']
-  }
+  },
+  ignorePatterns: ['deprecated/*']
 };

--- a/deprecated/halloween.ts
+++ b/deprecated/halloween.ts
@@ -1,5 +1,7 @@
-import { logger } from '../utilities/logger';
-import { ReactionDef } from './reaction-def';
+//@ts-nocheck
+//disable error checking for archived code
+import { logger } from '../src/utilities/logger';
+import { ReactionDef } from '../src/reactions/reaction-def';
 
 export const halloweenReaction: ReactionDef = {
   emoji: '🎃',

--- a/src/config/get-config.ts
+++ b/src/config/get-config.ts
@@ -95,16 +95,6 @@ export interface Config {
    * Option to enable/disable the thanks feature.
    */
   THANK_OPTION: boolean;
-  /**
-   * Announcement message ID for Halloween event. This should be the ID
-   * of the message users can react to and receive HALLOWEEN_ROLE.
-   */
-  HALLOWEEN_ANNOUNCEMENT: string;
-  /**
-   * Role for Halloween event. The role grants access to the halloween event channel,
-   * which is the channel the Trick'cord Treat bot will be operating in.
-   */
-  HALLOWEEN_ROLE: string;
 }
 /**
  * @name getConfig
@@ -130,8 +120,6 @@ export function getConfig(): Config {
     AUTO_LINK_CHANNEL: process.env.AUTO_LINK_CHANNEL || false,
     STREAM_NOTIFY_ROLE: process.env.STREAM_NOTIFY_ROLE || '',
     STREAM_MSG_ID: process.env.STREAM_MSG_ID || '',
-    THANK_OPTION: !!process.env.THANK_OPTION || false,
-    HALLOWEEN_ANNOUNCEMENT: process.env.HALLOWEEN_ANNOUNCEMENT || '',
-    HALLOWEEN_ROLE: process.env.HALLOWEEN_ROLE || ''
+    THANK_OPTION: !!process.env.THANK_OPTION || false
   };
 }

--- a/src/reactions/reactions.ts
+++ b/src/reactions/reactions.ts
@@ -2,7 +2,6 @@ import { ReactionDef } from './reaction-def';
 import { pin } from './pin';
 import { formatReaction } from './format-reaction';
 import { liveStreamReaction } from './livestream-reaction';
-import { halloweenReaction } from './halloween';
 
 /**
  * List of commands to react based on message reactions
@@ -10,6 +9,5 @@ import { halloweenReaction } from './halloween';
 export const REACTIONS: Array<ReactionDef> = [
   pin,
   formatReaction,
-  liveStreamReaction,
-  halloweenReaction
+  liveStreamReaction
 ];


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

**Description:**

This PR removes the Halloween feature for the bot - the event ends soon. 
* Moves Halloween reaction to new `deprecated` folder (saving code is a good idea).
* Removes config values.
* Sets linter to ignore `deprecated` folder.

If we'd rather just delete the file entirely, I can do that too.

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
