### PR TITLE
feat: send appeal link on ban

### DIFF
--- a/src/modules/sendModerationDm.ts
+++ b/src/modules/sendModerationDm.ts
@@ -32,6 +32,13 @@ export const sendModerationDm = async (
       )}`
     );
 
+    if (action === "ban") {
+      embed.addField(
+        "Appeals",
+        "You can use [this google form](https://docs.google.com/forms/d/e/1FAIpQLSdhJjpK8dPlktQMEatUwmXworqZF9ig14oiwmiZzd0skz5ekQ/viewform) to appeal your ban after you have [read our code of conduct](https://www.freecodecamp.org/news/code-of-conduct)."
+      );
+    }
+
     const sent = await user
       .send({ embeds: [embed] })
       .then(() => true)


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This adds a ban appeal link to the message sent when we ban someone. This link is a Google Form, which posts responses to a webhook in our Discord server for the moderation team to discuss.