### PR TITLE
feat: expose github error in error response

### DIFF
--- a/src/commands/subcommands/github/handleClose.ts
+++ b/src/commands/subcommands/github/handleClose.ts
@@ -81,7 +81,12 @@ export const handleClose: Subcommand = {
       });
     } catch (err) {
       await errorHandler(Bot, err);
-      await interaction.editReply("Something went wrong.");
+      await interaction.editReply(
+        `Something went wrong: ${
+          (err as Error).message ??
+          "Unable to parse error. Please check the logs."
+        }`
+      );
     }
   },
 };

--- a/src/commands/subcommands/github/handleComment.ts
+++ b/src/commands/subcommands/github/handleComment.ts
@@ -47,7 +47,12 @@ export const handleComment: Subcommand = {
       });
     } catch (err) {
       await errorHandler(Bot, err);
-      await interaction.editReply("Something went wrong.");
+      await interaction.editReply(
+        `Something went wrong: ${
+          (err as Error).message ??
+          "Unable to parse error. Please check the logs."
+        }`
+      );
     }
   },
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #460

<!-- Feel free to add any additional description of changes below this line -->

Generally we only pipe errors to the logs and display a generic message to the end-user. But because this is a staff only command (and GitHub's API errors tend to have a user-friendly message), we can go ahead and expose this directly in the response.