### PR TITLE
feat: standard response for exercise PRs raised against boilerplate repo

### DIFF
--- a/src/config/PullComments.ts
+++ b/src/config/PullComments.ts
@@ -55,6 +55,11 @@ export const PullComments: { key: string; message: string }[] = [
     key: "Failing CI",
     message:
       "We would love to be able to merge your changes but it looks like there is an error with the CI build. ⚠️\n\nOnce you resolve these issues, we will be able to review your PR and merge it. 😊\n\n---\n\nFeel free to reference the [contributing guidelines](https://contribute.freecodecamp.org/#/how-to-work-on-coding-challenges.md#testing-challenges) for instructions on running the CI build locally. ✅"
+  },
+  {
+    key: "Exercise PR Made Against Boilerplate Repo",
+    message:
+      "Hi there,\n\nIt looks like this PR was supposed to be made on your own fork instead of the original boilerplate repository.\n\nThis is a standard message notifying you that we've reviewed your pull request and have decided not to merge it. Join our [chat room](https://discord.gg/PRyKn3Vbay) or our [forum](https://forum.freecodecamp.org/) if you have any questions or need help with the coding challenges.\n\nHappy coding.",
   }
 ];
 

--- a/src/config/PullComments.ts
+++ b/src/config/PullComments.ts
@@ -59,7 +59,7 @@ export const PullComments: { key: string; message: string }[] = [
   {
     key: "Exercise PR Made Against Boilerplate Repo",
     message:
-      "Hi there,\n\nIt looks like this PR was supposed to be made on your own fork instead of the original boilerplate repository.\n\nThis is a standard message notifying you that we've reviewed your pull request and have decided not to merge it. Join our [chat room](https://discord.gg/PRyKn3Vbay) or our [forum](https://forum.freecodecamp.org/) if you have any questions or need help with the coding challenges.\n\nHappy coding."
+      "Hi there,\n\nIt looks like this PR was supposed to be made on your own fork instead of the original boilerplate repository.\n\nAs such, this isn't a PR we can merge to our repository. Feel free to join our [chat room](https://discord.gg/PRyKn3Vbay) or our [forum](https://forum.freecodecamp.org/) if you have any questions or need help with the coding challenges.\n\nHappy coding."
   }
 ];
 

--- a/src/config/PullComments.ts
+++ b/src/config/PullComments.ts
@@ -59,7 +59,7 @@ export const PullComments: { key: string; message: string }[] = [
   {
     key: "Exercise PR Made Against Boilerplate Repo",
     message:
-      "Hi there,\n\nIt looks like this PR was supposed to be made on your own fork instead of the original boilerplate repository.\n\nThis is a standard message notifying you that we've reviewed your pull request and have decided not to merge it. Join our [chat room](https://discord.gg/PRyKn3Vbay) or our [forum](https://forum.freecodecamp.org/) if you have any questions or need help with the coding challenges.\n\nHappy coding.",
+      "Hi there,\n\nIt looks like this PR was supposed to be made on your own fork instead of the original boilerplate repository.\n\nThis is a standard message notifying you that we've reviewed your pull request and have decided not to merge it. Join our [chat room](https://discord.gg/PRyKn3Vbay) or our [forum](https://forum.freecodecamp.org/) if you have any questions or need help with the coding challenges.\n\nHappy coding."
   }
 ];
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Adds a standard response that can be used in with the `/github close` command on exercise PRs that raised against boilerplate repos.

<!-- Feel free to add any additional description of changes below this line -->
