### PR TITLE
fix: typo in the Merge Conflicts comment

### DIFF
--- a/src/config/PullComments.ts
+++ b/src/config/PullComments.ts
@@ -11,7 +11,7 @@ export const PullComments: { key: string; message: string }[] = [
   },
   {
     key: "Merge Conflicts",
-    message: `We would love to be able to merge your changes, but it looks like you have some merge conflicts. ⚠️\n\nOnce you resolve these conflicts, we will be able to review you rPR and merge it. 😊\n\n---\n\nIf you're not familiar with the merge conflict process, feel free to look over GitHub's guide on ["Resolving a merge conflict"](https://help.github.com/articles/resolving-a-merge-conflict-on-github/). 🔍️\n\nAlso, it's good practice on GitHub to write a brief description of your changes when creating a PR. 📝`
+    message: `We would love to be able to merge your changes, but it looks like you have some merge conflicts. ⚠️\n\nOnce you resolve these conflicts, we will be able to review your PR and merge it. 😊\n\n---\n\nIf you're not familiar with the merge conflict process, feel free to look over GitHub's guide on ["Resolving a merge conflict"](https://help.github.com/articles/resolving-a-merge-conflict-on-github/). 🔍️\n\nAlso, it's good practice on GitHub to write a brief description of your changes when creating a PR. 📝`
   },
   {
     key: "Duplicate PR",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fixes a typo in the Merge Conflicts comment.

<!-- Feel free to add any additional description of changes below this line -->
