### PR TITLE
feat: let mods choose issue close reason (completed/not planned/duplicate)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,7 +22,7 @@ export default [
   {
     files: ["src/commands/subcommands/github/*.ts"],
     rules: {
-      camelcase: ["error", { allow: ["issue_number"] }]
+      camelcase: ["error", { allow: ["issue_number", "state_reason"] }]
     }
   },
   {

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -60,6 +60,25 @@ export const github: Command = {
           return option.
             setName("spam").
             setDescription("Label the PR as spam for Hacktoberfest?");
+        }).
+        addStringOption((option) => {
+          return option.
+            setName("reason").
+            setDescription(
+              `Why the issue is being closed. Defaults to not planned. Ignored for pull requests.`,
+            ).
+            addChoices(
+              { name: "completed", value: "completed" },
+              { name: "not planned", value: "not_planned" },
+              { name: "duplicate", value: "duplicate" },
+            );
+        }).
+        addIntegerOption((option) => {
+          return option.
+            setName("duplicate-of").
+            setDescription(
+              `The number of the issue or pull this is a duplicate of. Used when reason is duplicate.`,
+            );
         }),
     ).
     addSubcommand(

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -65,7 +65,7 @@ export const github: Command = {
           return option.
             setName("reason").
             setDescription(
-              `Why the issue is being closed. Defaults to not planned. Ignored for pull requests.`,
+              `Why the issue is being closed. Defaults to not planned. Not valid for pull requests.`,
             ).
             addChoices(
               { name: "completed", value: "completed" },

--- a/src/commands/subcommands/github/handleClose.ts
+++ b/src/commands/subcommands/github/handleClose.ts
@@ -58,10 +58,12 @@ export const handleClose: Subcommand = {
         owner:        "freeCodeCamp",
         repo:         repo,
         state:        "closed",
-        // eslint-disable-next-line @typescript-eslint/naming-convention -- Github API name.
-        state_reason: isPull
-          ? undefined
-          : "not_planned",
+        ...isPull
+          ? {}
+          : {
+            // eslint-disable-next-line @typescript-eslint/naming-convention -- Github API name.
+            state_reason: "not_planned" as const,
+          },
       });
       if (isPull && isSpam) {
         await camperChan.octokit.rest.issues.addLabels({

--- a/src/commands/subcommands/github/handleClose.ts
+++ b/src/commands/subcommands/github/handleClose.ts
@@ -62,7 +62,7 @@ export const handleClose: Subcommand = {
           ? {}
           : {
             // eslint-disable-next-line @typescript-eslint/naming-convention -- Github API name.
-            state_reason: "not_planned" as const,
+            state_reason: "not_planned",
           },
       });
       if (isPull && isSpam) {

--- a/src/commands/subcommands/github/handleClose.ts
+++ b/src/commands/subcommands/github/handleClose.ts
@@ -26,6 +26,10 @@ export const handleClose: Subcommand = {
       const number = interaction.options.getInteger("number", true);
       const comment = interaction.options.getString("comment") ?? null;
       const isSpam = interaction.options.getBoolean("spam") ?? false;
+      const reasonInput = interaction.options.getString("reason");
+      const reason = reasonInput ?? "not_planned";
+      const duplicateOf
+        = interaction.options.getInteger("duplicate-of") ?? null;
 
       const data = await camperChan.octokit.rest.issues.get({
         // eslint-disable-next-line @typescript-eslint/naming-convention -- Github API name.
@@ -45,6 +49,42 @@ export const handleClose: Subcommand = {
         return;
       }
       const isPull = Boolean(data.data.pull_request);
+
+      if (isPull && (reasonInput !== null || duplicateOf !== null)) {
+        await interaction.editReply({
+          content:
+            `The \`reason\` and \`duplicate-of\` options only apply to issues, not pull requests.`,
+        });
+        return;
+      }
+
+      const isDuplicate = !isPull && reason === "duplicate";
+
+      let duplicateNodeId: string | null = null;
+      if (isDuplicate) {
+        if (duplicateOf === null) {
+          await interaction.editReply({
+            content:
+              `Please provide the \`duplicate-of\` number when closing an issue as a duplicate.`,
+          });
+          return;
+        }
+        const duplicate = await camperChan.octokit.rest.issues.get({
+          // eslint-disable-next-line @typescript-eslint/naming-convention -- Github API name.
+          issue_number: duplicateOf,
+          owner:        "freeCodeCamp",
+          repo:         repo,
+        });
+        if (duplicate.data.pull_request) {
+          await interaction.editReply({
+            content:
+              `The \`duplicate-of\` number must be an issue, but [#${String(duplicateOf)}](<${duplicate.data.html_url}>) is a pull request.`,
+          });
+          return;
+        }
+        duplicateNodeId = duplicate.data.node_id;
+      }
+
       await camperChan.octokit.rest.issues.createComment({
         body:         commentBody(isPull, comment),
         // eslint-disable-next-line @typescript-eslint/naming-convention -- Github API name.
@@ -52,19 +92,40 @@ export const handleClose: Subcommand = {
         owner:        "freeCodeCamp",
         repo:         repo,
       });
-      await camperChan.octokit.rest.issues.update({
-        // eslint-disable-next-line @typescript-eslint/naming-convention -- Github API name.
-        issue_number: number,
-        owner:        "freeCodeCamp",
-        repo:         repo,
-        state:        "closed",
-        ...isPull
-          ? {}
-          : {
-            // eslint-disable-next-line @typescript-eslint/naming-convention -- Github API name.
-            state_reason: "not_planned",
+
+      if (duplicateNodeId === null) {
+        await camperChan.octokit.rest.issues.update({
+          // eslint-disable-next-line @typescript-eslint/naming-convention -- Github API name.
+          issue_number: number,
+          owner:        "freeCodeCamp",
+          repo:         repo,
+          state:        "closed",
+          ...isPull
+            ? {}
+            : {
+              // eslint-disable-next-line @typescript-eslint/naming-convention -- Github API name.
+              state_reason: reason === "completed"
+                ? "completed"
+                : "not_planned",
+            },
+        });
+      } else {
+        await camperChan.octokit.graphql(
+          `mutation($issueId: ID!, $duplicateIssueId: ID!) {
+            closeIssue(input: {
+              issueId: $issueId,
+              stateReason: DUPLICATE,
+              duplicateIssueId: $duplicateIssueId
+            }) {
+              issue { id }
+            }
+          }`,
+          {
+            duplicateIssueId: duplicateNodeId,
+            issueId:          data.data.node_id,
           },
-      });
+        );
+      }
       if (isPull && isSpam) {
         await camperChan.octokit.rest.issues.addLabels({
           // eslint-disable-next-line @typescript-eslint/naming-convention -- Github API name.

--- a/src/commands/subcommands/github/handleClose.ts
+++ b/src/commands/subcommands/github/handleClose.ts
@@ -58,7 +58,7 @@ export const handleClose: Subcommand = {
         owner:        "freeCodeCamp",
         repo:         repo,
         state:        "closed",
-        // eslint-disable-next-line @typescript-eslint/naming-convention, camelcase -- Github API name.
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- Github API name.
         state_reason: isPull
           ? undefined
           : "not_planned",

--- a/src/commands/subcommands/github/handleClose.ts
+++ b/src/commands/subcommands/github/handleClose.ts
@@ -58,6 +58,10 @@ export const handleClose: Subcommand = {
         owner:        "freeCodeCamp",
         repo:         repo,
         state:        "closed",
+        // eslint-disable-next-line @typescript-eslint/naming-convention, camelcase -- Github API name.
+        state_reason: isPull
+          ? undefined
+          : "not_planned",
       });
       if (isPull && isSpam) {
         await camperChan.octokit.rest.issues.addLabels({

--- a/test/commands/github.spec.ts
+++ b/test/commands/github.spec.ts
@@ -31,7 +31,7 @@ describe("github command", () => {
       close?.description,
       "Close an issue or pull request under the freeCodeCamp organisation.",
     );
-    assert.lengthOf(close?.options || "hi", 4);
+    assert.lengthOf(close?.options || "hi", 6);
     assert.strictEqual(close?.options?.[0].name, "repository");
     assert.strictEqual(
       close?.options?.[0].description,
@@ -71,6 +71,26 @@ describe("github command", () => {
     assert.strictEqual(
       close?.options?.[3].type,
       ApplicationCommandOptionType.Boolean,
+    );
+    assert.strictEqual(close?.options?.[4].name, "reason");
+    assert.strictEqual(
+      close?.options?.[4].description,
+      `Why the issue is being closed. Defaults to not planned. Ignored for pull requests.`,
+    );
+    assert.isFalse(close?.options?.[4].required);
+    assert.strictEqual(
+      close?.options?.[4].type,
+      ApplicationCommandOptionType.String,
+    );
+    assert.strictEqual(close?.options?.[5].name, "duplicate-of");
+    assert.strictEqual(
+      close?.options?.[5].description,
+      `The number of the issue or pull this is a duplicate of. Used when reason is duplicate.`,
+    );
+    assert.isFalse(close?.options?.[5].required);
+    assert.strictEqual(
+      close?.options?.[5].type,
+      ApplicationCommandOptionType.Integer,
     );
   });
 

--- a/test/commands/github.spec.ts
+++ b/test/commands/github.spec.ts
@@ -75,7 +75,7 @@ describe("github command", () => {
     assert.strictEqual(close?.options?.[4].name, "reason");
     assert.strictEqual(
       close?.options?.[4].description,
-      `Why the issue is being closed. Defaults to not planned. Ignored for pull requests.`,
+      `Why the issue is being closed. Defaults to not planned. Not valid for pull requests.`,
     );
     assert.isFalse(close?.options?.[4].required);
     assert.strictEqual(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->

When closing an issue via the `/github close` command, CamperChan previously closed it without a `state_reason`, which caused GitHub to default to "completed" (shown as "resolved" in the UI). This PR lets moderators choose the close reason instead.

Two new optional options are added to `/github close`:

- `reason`: choose between `completed`, `not planned`, and `duplicate`. Defaults to `not planned`, so the existing behavior is preserved when the option is omitted.
- `duplicate-of`: the issue number this one duplicates. Required when `reason` is `duplicate`.

`completed` and `not planned` are applied via the REST `issues.update` endpoint. `duplicate` uses the GraphQL `closeIssue` mutation with `stateReason: DUPLICATE` and `duplicateIssueId`, which creates the real "marked as a duplicate of #N" linkage that REST cannot.

Validation (each replies in Discord and aborts before any change is made):

- Selecting `reason` or `duplicate-of` while closing a pull request is rejected, since these only apply to issues.
- Choosing `duplicate` without a `duplicate-of` number is rejected.
- A `duplicate-of` that points to a pull request is rejected, since the duplicate target must be an issue.
