### PR TITLE
fix: allow reporting messages with no text content

### DIFF
--- a/src/contexts/report.ts
+++ b/src/contexts/report.ts
@@ -31,7 +31,8 @@ export const report: Context = {
 
       const { reportChannel } = camperChan;
 
-      const { author, url, content, channel } = message;
+      const { author, url, content, channel, attachments, stickers, embeds }
+        = message;
 
       const linkButton = new ButtonBuilder().
         setStyle(ButtonStyle.Link).
@@ -47,9 +48,43 @@ export const report: Context = {
         acknowledgeButton,
       ]);
 
+      /*
+       * A message may have no text at all, but the embed description cannot
+       * be an empty string. Summarise the non-text payload instead.
+       */
+      const descriptionParts = [ content ];
+      if (stickers.size > 0) {
+        descriptionParts.push(`**Stickers:** ${stickers.map((sticker) => {
+          return sticker.name;
+        }).join(", ")}`);
+      }
+      if (attachments.size > 0) {
+        descriptionParts.push(`**Attachments:** ${attachments.
+          map((attachment) => {
+            return attachment.proxyURL;
+          }).join("\n")}`);
+      }
+      if (embeds.length > 0) {
+        descriptionParts.push(`**Embeds:** ${String(embeds.length)}`);
+      }
+      const description = descriptionParts.
+        filter(Boolean).
+        join("\n\n").
+        slice(0, 4000);
+
       const reportEmbed = new EmbedBuilder();
       reportEmbed.setTitle("A message was flagged for review!");
-      reportEmbed.setDescription(content.slice(0, 4000));
+      reportEmbed.setDescription(
+        description === ""
+          ? "*This message has no text. Use the message link to view it.*"
+          : description,
+      );
+      const image = attachments.find((attachment) => {
+        return attachment.contentType?.startsWith("image/") ?? false;
+      });
+      if (image) {
+        reportEmbed.setImage(image.proxyURL);
+      }
       reportEmbed.setAuthor({
         iconURL: author.displayAvatarURL(),
         name:    author.tag,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->

Reporting a message that has no text content silently fails.

`src/contexts/report.ts` built the report embed with `setDescription(content.slice(0, 4000))`. For an attachment-only, sticker-only or embed-only message, `content` is an empty string, and `EmbedBuilder#setDescription` rejects that:

```
s.string().lengthGreaterThanOrEqual()  given: ""  expected: expected.length >= 1
```

The throw happens before `reportChannel.send()`, so:

- no report reaches the report channel,
- `interaction.showModal()` is never called, so the interaction receives no response at all: the reporter gets no reason prompt and sees "The application did not respond",
- the only trace is the error webhook.

That means image-only spam, sticker abuse and link-embed messages cannot be reported at all.

This builds the description from whatever the message actually carries: text if present, then sticker names, attachment URLs and an embed count, falling back to a short placeholder when there is nothing to show. It also sets the first image attachment as the embed image so moderators can see the reported content without following the link.
