### PR TITLE
fix: mention the reporter in voice report messages

### DIFF
--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -53,7 +53,7 @@ export const report: Command = {
       }
 
       await reportChannel.send({
-        content: `<@{interaction.user.id}> has reported <@${target.id}> for the following behaviour in <#${voice.id}>:\n${reason}`,
+        content: `<@${interaction.user.id}> has reported <@${target.id}> for the following behaviour in <#${voice.id}>:\n${reason}`,
       });
       await interaction.editReply({
         content:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->

The template literal in the `/report` voice command was missing the `$` on the first interpolation, so the message posted to the report channel contained the literal text `<@{interaction.user.id}>` instead of mentioning the reporter.

This adds the missing `$`.
