### PR TITLE
feat: log the offending message in automoderation ban reports

### DIFF
--- a/src/events/handlers/handleMessageCreate.ts
+++ b/src/events/handlers/handleMessageCreate.ts
@@ -170,13 +170,18 @@ export const handleMessageCreate = async(
     if (attached) {
       banLogEmbed.setImage(attached.proxyURL);
     }
-    banLogEmbed.setTimestamp();
+
+    /*
+     * The log message carries its own timestamp, so this preserves when the
+     * offending message was sent instead.
+     */
+    banLogEmbed.setTimestamp(message.createdAt);
     banLogEmbed.setAuthor({
       iconURL: message.author.displayAvatarURL(),
       name:    message.author.tag,
     });
     banLogEmbed.setFooter({
-      text: `ID: ${message.author.id}`,
+      text: `ID: ${message.author.id} | Message sent`,
     });
 
     await camperChan.config.modHook.send({ embeds: [ banLogEmbed ] });

--- a/src/events/handlers/handleMessageCreate.ts
+++ b/src/events/handlers/handleMessageCreate.ts
@@ -89,16 +89,35 @@ export const handleMessageCreate = async(
   const inviteWithPing
     = MessageMentions.EveryonePattern.test(message.content)
     && await hasNonApprovedInvite(camperChan, message.content);
-  const isCompromised
-    = await hasKnownPhishingLink(camperChan, message.content)
-    || inviteWithPing
-    // This channel is the "honeypot" channel. Regular members should never post in here.
-    || message.channel.id === "1286391728919810150";
+  const hasPhishingLink
+    = await hasKnownPhishingLink(camperChan, message.content);
+  // This channel is the "honeypot" channel. Regular members should never post in here.
+  const isHoneypotPost = message.channel.id === "1286391728919810150";
+  const triggers = [
+    hasPhishingLink && "Known phishing link",
+    inviteWithPing && "Unapproved invite with a mass ping",
+    isHoneypotPost && "Posted in the honeypot channel",
+  ].filter((trigger): trigger is string => {
+    return typeof trigger === "string";
+  });
+  const isCompromised = triggers.length > 0;
 
   const isBannable = Boolean(message.member?.bannable);
 
   if (isCompromised && isBannable) {
     const reason = "Your account appears to be compromised.";
+    // Recorded before the ban, as banning prunes the message itself.
+    const stickerNames = message.stickers.map((sticker) => {
+      return sticker.name;
+    }).join(" ");
+    const messageText
+      = message.content === ""
+        ? "no content"
+        : message.content;
+    const loggedContent = customSubstring(
+      [ messageText, stickerNames ].filter(Boolean).join(" "),
+      1000,
+    );
     const sentNotice = await sendModerationDm(
       camperChan,
       {
@@ -125,10 +144,32 @@ export const handleMessageCreate = async(
         value: customSubstring(reason, 1000),
       },
       {
+        name:  "Trigger",
+        value: triggers.join("\n"),
+      },
+      {
+        inline: true,
+        name:   "Channel",
+        value:  `<#${message.channel.id}>`,
+      },
+      {
+        inline: true,
+        name:   "Message",
+        value:  message.url,
+      },
+      {
+        name:  "Content",
+        value: loggedContent,
+      },
+      {
         name:  "User notified?",
         value: String(sentNotice),
       },
     ]);
+    const attached = message.attachments.first();
+    if (attached) {
+      banLogEmbed.setImage(attached.proxyURL);
+    }
     banLogEmbed.setTimestamp();
     banLogEmbed.setAuthor({
       iconURL: message.author.displayAvatarURL(),
@@ -139,6 +180,12 @@ export const handleMessageCreate = async(
     });
 
     await camperChan.config.modHook.send({ embeds: [ banLogEmbed ] });
+
+    if (message.embeds.length > 0) {
+      await Promise.all(message.embeds.map(async(embed) => {
+        return await camperChan.config.modHook.send({ embeds: [ embed ] });
+      }));
+    }
   }
 
   await messageCounter(camperChan, message);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->

When automoderation bans someone for a compromised account, the report sent to the mod channel contains only the reason, whether the user was notified, and the user's tag and ID. There is no record of the message that triggered the ban, or of which of the three automod rules fired.

The message is gone by the time anyone reads the report, since the ban always prunes a day of the user's messages. The deletion log is not a reliable fallback for it either: the client is constructed without `Partials.Message`, so delete and bulk delete events are dropped entirely for any message that is not in the bot's cache, and those logs go to a different webhook than the ban report anyway.

This records the evidence at the point of the ban, where the message object is guaranteed to be in hand, and adds it to the existing ban embed:

- **Trigger** - which rule fired: known phishing link, unapproved invite with a mass ping, or a post in the honeypot channel. The three checks were previously collapsed into a single boolean, so this splits them out. They are all evaluated as often as before, so this adds no extra requests to the phishing or invite APIs.
- **Channel** and **Message** - the channel mention and the jump URL. The jump link points at a message the ban has deleted, so it will not load, but it preserves the guild, channel and message IDs for cross-referencing the audit log.
- **Content** - the message text, plus any sticker names, truncated to 1000 characters. This mirrors what `handleMessageDelete` records, including its `no content` fallback, which also keeps the embed field from being rejected for being empty.
- The first attachment as the embed image, and any embeds the message carried as follow-up messages, both matching `handleMessageDelete`. Attachment proxy URLs stop resolving once Discord drops the pruned message, so the text content is the durable part.

The embed timestamp previously recorded when the report was logged, which is already the log message's own timestamp. It now records when the offending message was sent, labelled in the footer so it cannot be misread:

```
ID: 465650873650118659 | Message sent • 03/08/2026 19:09
```

For this report the two are only seconds apart, since the ban fires on message creation. The change is here to match https://github.com/freeCodeCamp/CamperChan-discord/pull/953, which adds the same timestamp to the message deletion log, where it is genuinely useful.

The message sent to the banned user, the audit log reason on the ban, and the manual `/ban` command are all unchanged. The manual ban builds its own separate embed, so it is unaffected.
