### PR TITLE
feat: preserve the sent timestamp in message deletion logs

### DIFF
--- a/src/events/handlers/handleMessageDelete.ts
+++ b/src/events/handlers/handleMessageDelete.ts
@@ -21,7 +21,7 @@ export const handleMessageDelete = async(
       embeds,
       attachments,
       stickers,
-      createdAt,
+      createdTimestamp,
     } = message;
 
     if (!guild) {
@@ -37,6 +37,10 @@ export const handleMessageDelete = async(
         value: `<#${channel.id}>`,
       },
       {
+        name:  "Sent",
+        value: `<t:${String(Math.floor(createdTimestamp / 1000))}:f>`,
+      },
+      {
         name:  "Content",
         value: customSubstring(
           (content ?? "no content") + stickers.map((element) => {
@@ -47,19 +51,13 @@ export const handleMessageDelete = async(
       },
     );
 
-    /*
-     * The log message carries its own timestamp, so this preserves when the
-     * deleted message was sent instead.
-     */
-    deleteEmbed.setTimestamp(createdAt);
-
     if (author) {
       deleteEmbed.setAuthor({
         iconURL: author.displayAvatarURL(),
         name:    author.tag,
       });
       deleteEmbed.setFooter({
-        text: `ID: ${author.id} | Message sent`,
+        text: `ID: ${author.id}`,
       });
     }
 

--- a/src/events/handlers/handleMessageDelete.ts
+++ b/src/events/handlers/handleMessageDelete.ts
@@ -13,8 +13,16 @@ export const handleMessageDelete = async(
   message: Message | PartialMessage,
 ): Promise<void> => {
   try {
-    const { author, channel, content, guild, embeds, attachments, stickers }
-      = message;
+    const {
+      author,
+      channel,
+      content,
+      guild,
+      embeds,
+      attachments,
+      stickers,
+      createdAt,
+    } = message;
 
     if (!guild) {
       return;
@@ -39,13 +47,19 @@ export const handleMessageDelete = async(
       },
     );
 
+    /*
+     * The log message carries its own timestamp, so this preserves when the
+     * deleted message was sent instead.
+     */
+    deleteEmbed.setTimestamp(createdAt);
+
     if (author) {
       deleteEmbed.setAuthor({
         iconURL: author.displayAvatarURL(),
         name:    author.tag,
       });
       deleteEmbed.setFooter({
-        text: `ID: ${author.id}`,
+        text: `ID: ${author.id} | Message sent`,
       });
     }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->

The message deletion log records the channel, the content, the author and any attachment, but never when the message was actually sent. The embed sets no timestamp at all, so the only time reference is the log message's own, which is when the log arrived rather than when the message was posted. Under any delay, and especially during a bulk deletion where the log entries are queued behind each other, that tells you nothing useful about the original message.

This sets the embed timestamp to the message's creation time, and labels it in the footer so it cannot be misread as the time of logging:

```
ID: 465650873650118659 | Message sent • 03/08/2026 19:09
```

The log message already carries its own timestamp, so nothing is duplicated by this.

`createdAt` is derived from the message snowflake rather than the gateway payload, so it is accurate even for a partial message where the content and author are unavailable.

Discord sends no timestamp with `MESSAGE_DELETE` or `MESSAGE_DELETE_BULK`, so the time of deletion itself cannot be recorded. The log message's own timestamp remains the closest available approximation of it.
