### PR TITLE
feat: allow staff to assign roles on behalf of users

### DIFF
--- a/src/commands/management.ts
+++ b/src/commands/management.ts
@@ -5,19 +5,39 @@ import {
   SlashCommandSubcommandBuilder,
 } from "discord.js";
 import { errorHandler } from "../utils/errorHandler.js";
+import { handleAssignRole } from "./subcommands/management/handleAssignRole.js";
 import { handlePrivate } from "./subcommands/management/handlePrivate.js";
 import { handleRole } from "./subcommands/management/handleRole.js";
 import { handleTickets } from "./subcommands/management/handleTickets.js";
 import type { Command } from "../interfaces/command.js";
 import type { Subcommand } from "../interfaces/subcommand.js";
 
+/* eslint-disable @typescript-eslint/naming-convention -- These keys are subcommand names, which Discord requires to be kebab-case. */
 const handlers: Record<string, Subcommand> = {
-  private: handlePrivate,
-  role:    handleRole,
-  tickets: handleTickets,
+  "assign-role": handleAssignRole,
+  "private":     handlePrivate,
+  "role":        handleRole,
+  "tickets":     handleTickets,
 };
+/* eslint-enable @typescript-eslint/naming-convention -- Re-enabled after the subcommand map. */
 
 export const management: Command = {
+  autocomplete: async(camperChan, interaction) => {
+    try {
+      const handler = handlers[interaction.options.getSubcommand(true)];
+      if (!handler?.autocomplete
+        || !handler.permissionValidator(interaction.member)) {
+        await interaction.respond([]);
+        return;
+      }
+      await handler.autocomplete(camperChan, interaction);
+    } catch (error) {
+      await errorHandler(camperChan, "management autocomplete", error);
+      await interaction.respond([]).catch(() => {
+        return null;
+      });
+    }
+  },
   data: new SlashCommandBuilder().
     setName("management").
     setDescription("Commands related to server management.").
@@ -72,6 +92,24 @@ export const management: Command = {
         addRoleOption((option) => {
           return option.setName("role5").
             setDescription("Role to create a button for.");
+        }),
+    ).
+    addSubcommand(
+      new SlashCommandSubcommandBuilder().
+        setName("assign-role").
+        setDescription("Adds or removes a role for a user on their behalf.").
+        addUserOption((option) => {
+          return option.
+            setName("target").
+            setDescription("The user to update the roles of.").
+            setRequired(true);
+        }).
+        addStringOption((option) => {
+          return option.
+            setName("role").
+            setDescription("The role to add to, or remove from, the user.").
+            setRequired(true).
+            setAutocomplete(true);
         }),
     ).
     addSubcommand(

--- a/src/commands/subcommands/management/handleAssignRole.ts
+++ b/src/commands/subcommands/management/handleAssignRole.ts
@@ -1,0 +1,127 @@
+import {
+  type Guild,
+  type GuildMember,
+  PermissionFlagsBits,
+  type Role,
+} from "discord.js";
+import { errorHandler } from "../../../utils/errorHandler.js";
+import type { Subcommand } from "../../../interfaces/subcommand.js";
+
+/**
+ * Determines if the camperChan is allowed to hand out a role. Everything
+ * below the camperChan's own highest role is fair game, except the everyone
+ * role and roles owned by an integration, such as the booster role.
+ * @param guild - The guild the role belongs to.
+ * @param bot - The camperChan's member record in that guild.
+ * @param role - The role to check.
+ * @returns True when the role may be assigned.
+ */
+const isAssignable = (guild: Guild, bot: GuildMember, role: Role): boolean => {
+  return (
+    role.id !== guild.id
+    && !role.managed
+    && bot.roles.highest.comparePositionTo(role) > 0
+  );
+};
+
+export const handleAssignRole: Subcommand = {
+  autocomplete: async(camperChan, interaction) => {
+    try {
+      const { guild, options } = interaction;
+      const bot = guild.members.me ?? await guild.members.fetchMe();
+      const query = options.getFocused().toLowerCase();
+      const roles = [ ...guild.roles.cache.values() ].
+        filter((role) => {
+          return (
+            isAssignable(guild, bot, role)
+            && role.name.toLowerCase().includes(query)
+          );
+        }).
+        sort((a, b) => {
+          return a.name.localeCompare(b.name);
+        }).
+        slice(0, 25).
+        map((role) => {
+          return { name: role.name, value: role.id };
+        });
+      await interaction.respond(roles);
+    } catch (error) {
+      await errorHandler(camperChan, "assign role autocomplete", error);
+      await interaction.respond([]).catch(() => {
+        return null;
+      });
+    }
+  },
+  execute: async(camperChan, interaction) => {
+    try {
+      await interaction.deferReply({ ephemeral: true });
+      const { guild, member, options } = interaction;
+      const target = options.getUser("target", true);
+      const roleId = options.getString("role", true);
+
+      const targetMember = await guild.members.fetch(target.id).catch(() => {
+        return null;
+      });
+
+      if (!targetMember) {
+        await interaction.editReply("They do not seem to be in the server.");
+        return;
+      }
+
+      const role = guild.roles.cache.get(roleId);
+
+      if (!role) {
+        await interaction.editReply("Cannot find that role.");
+        return;
+      }
+
+      const bot = guild.members.me ?? await guild.members.fetchMe();
+
+      if (!isAssignable(guild, bot, role)) {
+        await interaction.editReply(
+          `I cannot manage the ${role.name} role. I can only hand out roles that sit below my own highest role, and that are not owned by an integration.`,
+        );
+        return;
+      }
+
+      const hadRole = targetMember.roles.cache.has(role.id);
+
+      if (hadRole) {
+        await targetMember.roles.remove(role);
+      } else {
+        await targetMember.roles.add(role);
+      }
+
+      const action = hadRole
+        ? "removed"
+        : "added";
+      const preposition = hadRole
+        ? "from"
+        : "to";
+
+      /*
+       * The role is named rather than mentioned, so that this log does not
+       * ping everyone holding a mentionable role.
+       */
+      await camperChan.config.modHook.send({
+        content: `<@${member.user.id}> has ${action} the \`${role.name}\` role ${preposition} <@${target.id}>.`,
+      });
+
+      await interaction.editReply(
+        `I have ${action} the ${role.name} role ${preposition} ${target.username}.`,
+      );
+    } catch (error) {
+      await errorHandler(camperChan, "assign role subcommand", error);
+      await interaction.editReply("Something went wrong!");
+    }
+  },
+  permissionValidator: (member) => {
+    return [
+      PermissionFlagsBits.ModerateMembers,
+      PermissionFlagsBits.KickMembers,
+      PermissionFlagsBits.BanMembers,
+    ].some((p) => {
+      return member.permissions.has(p);
+    });
+  },
+};

--- a/src/events/handlers/handleInteractionCreate.ts
+++ b/src/events/handlers/handleInteractionCreate.ts
@@ -55,6 +55,27 @@ export const handleInteractionCreate = async(
     return;
   }
 
+  /*
+   * Autocomplete interactions can only be answered with a list of choices.
+   * Every path here must call respond, or the camper's client hangs until
+   * Discord times the interaction out.
+   */
+  if (interaction.isAutocomplete()) {
+    if (!interaction.inCachedGuild()) {
+      await interaction.respond([]);
+      return;
+    }
+    const target = camperChan.commands.find((command) => {
+      return command.data.name === interaction.commandName;
+    });
+    if (!target?.autocomplete) {
+      await interaction.respond([]);
+      return;
+    }
+    await target.autocomplete(camperChan, interaction);
+    return;
+  }
+
   if (interaction.isButton()) {
     if (interaction.customId === "ticket-open") {
       if (!interaction.inCachedGuild()) {

--- a/src/interfaces/command.ts
+++ b/src/interfaces/command.ts
@@ -1,5 +1,6 @@
 import type { ExtendedClient } from "./extendedClient.js";
 import type {
+  AutocompleteInteraction,
   ChatInputCommandInteraction,
   SlashCommandOptionsOnlyBuilder,
   SlashCommandSubcommandsOnlyBuilder,
@@ -10,5 +11,9 @@ export interface Command {
   run: (
     camperChan: ExtendedClient,
     interaction: ChatInputCommandInteraction<"cached">
+  )=> Promise<void>;
+  autocomplete?: (
+    camperChan: ExtendedClient,
+    interaction: AutocompleteInteraction<"cached">
   )=> Promise<void>;
 }

--- a/src/interfaces/subcommand.ts
+++ b/src/interfaces/subcommand.ts
@@ -1,11 +1,15 @@
 import type { ExtendedClient } from "./extendedClient.js";
 import type { GuildCommandInteraction } from "./guildCommandInteraction.js";
-import type { GuildMember } from "discord.js";
+import type { AutocompleteInteraction, GuildMember } from "discord.js";
 
 export interface Subcommand {
   permissionValidator: (member: GuildMember)=> boolean;
   execute: (
     camperChan: ExtendedClient,
     interaction: GuildCommandInteraction
+  )=> Promise<void>;
+  autocomplete?: (
+    camperChan: ExtendedClient,
+    interaction: AutocompleteInteraction<"cached">
   )=> Promise<void>;
 }

--- a/test/commands/management.spec.ts
+++ b/test/commands/management.spec.ts
@@ -18,7 +18,41 @@ describe("management command", () => {
       management.data.description,
       "Commands related to server management.",
     );
-    assert.lengthOf(subcommands, 3);
+    assert.lengthOf(subcommands, 4);
+  });
+
+  it("has correct assign-role", () => {
+    const assignRole = subcommands.find((sub) => {
+      return sub.name === "assign-role";
+    });
+    assert.strictEqual(
+      assignRole?.description,
+      "Adds or removes a role for a user on their behalf.",
+    );
+    assert.lengthOf(assignRole?.options || "hi", 2);
+    assert.strictEqual(assignRole?.options[0].name, "target");
+    assert.strictEqual(
+      assignRole?.options[0].description,
+      "The user to update the roles of.",
+    );
+    assert.isTrue(assignRole?.options[0].required);
+    assert.strictEqual(
+      assignRole?.options[0].type,
+      ApplicationCommandOptionType.User,
+    );
+    assert.strictEqual(assignRole?.options[1].name, "role");
+    assert.strictEqual(
+      assignRole?.options[1].description,
+      "The role to add to, or remove from, the user.",
+    );
+    assert.isTrue(assignRole?.options[1].required);
+    assert.strictEqual(
+      assignRole?.options[1].type,
+      ApplicationCommandOptionType.String,
+    );
+    assert.isTrue(
+      (assignRole?.options[1] as { autocomplete?: boolean }).autocomplete,
+    );
   });
 
   it("has correct private", () => {

--- a/test/commands/subcommands/management/handleAssignRole.spec.ts
+++ b/test/commands/subcommands/management/handleAssignRole.spec.ts
@@ -1,0 +1,142 @@
+import { PermissionFlagsBits } from "discord.js";
+import { describe, assert, it, vi } from "vitest";
+import { handleAssignRole }
+  from "../../../../src/commands/subcommands/management/handleAssignRole.js";
+import type { ExtendedClient }
+  from "../../../../src/interfaces/extendedClient.js";
+
+interface MockRole {
+  id:       string;
+  name:     string;
+  position: number;
+  managed:  boolean;
+}
+
+const guildId = "1";
+const botPosition = 10;
+
+const makeRole = (role: Partial<MockRole> & { id: string; name: string }):
+MockRole => {
+  return { managed: false, position: 1, ...role };
+};
+
+const roles = [
+  makeRole({ id: guildId, name: "@everyone", position: 0 }),
+  makeRole({ id: "2", name: "AI" }),
+  makeRole({ id: "3", managed: true, name: "Booster" }),
+  makeRole({ id: "4", name: "Contributors" }),
+  makeRole({ id: "5", name: "Moderators", position: 20 }),
+  makeRole({ id: "6", name: "Tied With Bot", position: botPosition }),
+];
+
+const makeInteraction = (
+  query: string,
+  roleList: Array<MockRole>,
+): { respond: ReturnType<typeof vi.fn> } => {
+  return {
+    guild: {
+      id:      guildId,
+      members: {
+        me: {
+          roles: {
+            highest: {
+              comparePositionTo: (role: MockRole): number => {
+                return botPosition - role.position;
+              },
+            },
+          },
+        },
+      },
+      roles: {
+        cache: new Map(roleList.map((role) => {
+          return [ role.id, role ];
+        })),
+      },
+    },
+    options: {
+      getFocused: (): string => {
+        return query;
+      },
+    },
+    respond: vi.fn(),
+  } as unknown as { respond: ReturnType<typeof vi.fn> };
+};
+
+const suggest = async(
+  query: string,
+  roleList: Array<MockRole> = roles,
+): Promise<Array<{ name: string; value: string }>> => {
+  const interaction = makeInteraction(query, roleList);
+  await handleAssignRole.autocomplete?.(
+    {} as ExtendedClient,
+    interaction as never,
+  );
+  return interaction.respond.mock.calls[0]?.[0] as Array<{
+    name:  string;
+    value: string;
+  }>;
+};
+
+describe("handleAssignRole command", () => {
+  it("does not allow members without moderation permissions", () => {
+    assert.isFalse(
+      handleAssignRole.permissionValidator({
+        permissions: new Set([ PermissionFlagsBits.SendMessages ]),
+      } as never),
+    );
+  });
+
+  it("allows moderate members permission", () => {
+    assert.isTrue(
+      handleAssignRole.permissionValidator({
+        permissions: new Set([ PermissionFlagsBits.ModerateMembers ]),
+      } as never),
+    );
+  });
+
+  it("allows kick members permission", () => {
+    assert.isTrue(
+      handleAssignRole.permissionValidator({
+        permissions: new Set([ PermissionFlagsBits.KickMembers ]),
+      } as never),
+    );
+  });
+
+  it("allows ban members permission", () => {
+    assert.isTrue(
+      handleAssignRole.permissionValidator({
+        permissions: new Set([ PermissionFlagsBits.BanMembers ]),
+      } as never),
+    );
+  });
+
+  it("only suggests roles the camperChan can assign", async() => {
+    assert.deepEqual(
+      await suggest(""),
+      [
+        { name: "AI", value: "2" },
+        { name: "Contributors", value: "4" },
+      ],
+      "everyone, managed, and too-high roles should be excluded",
+    );
+  });
+
+  it("filters the suggestions by what was typed", async() => {
+    assert.deepEqual(
+      await suggest("contrib"),
+      [ { name: "Contributors", value: "4" } ],
+      "only roles matching the query should be suggested",
+    );
+  });
+
+  it("never suggests more than the twenty five Discord allows", async() => {
+    const many = Array.from({ length: 30 }, (_unused, index) => {
+      return makeRole({ id: String(index + 100), name: `Role ${index}` });
+    });
+    assert.lengthOf(
+      await suggest("role", many),
+      25,
+      "the suggestion list should be capped at twenty five",
+    );
+  });
+});


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #943

<!-- Feel free to add any additional description of changes below this line -->

Adds `/management assign-role`, which toggles a role for a target member the same way the self-serve role buttons do. Moderators can now sort out campers who cannot work the onboarding UI.

The `role` option is autocompleted, and the list is computed live rather than configured: every role below the CamperChan's own highest role, minus the everyone role and minus roles owned by an integration, such as the booster role. Nothing to maintain when roles are added, moved, or removed. The same check runs again when the command executes, since a client can submit any string to an autocompleted option.

Autocomplete had no plumbing in this repository, so the first commit adds it: an optional `autocomplete` handler on the command and subcommand interfaces, plus a branch in `handleInteractionCreate` that dispatches to it. Every path there responds, because Discord accepts nothing but a choice list for these interactions and the camper's client hangs until timeout otherwise. The `management` command routes autocomplete through the same subcommand map as `run`, and runs the permission validator first, so non moderators get an empty list.

Role changes are posted to the mod webhook, in the same plain content style as the voice reports:

```md
<@moderator> has added the `AI` role to <@camper>.
```

Discord's audit log credits the CamperChan for the change, so without this there is no record of which moderator made it. The role is named rather than mentioned, so the log cannot ping everyone holding a mentionable role.

No configuration or permission changes are needed to deploy this. Commands are registered on boot, and the Manage Roles permission and the `GuildMembers` intent are both already in use.
